### PR TITLE
Add "Program", "Variable", "ImplicitCast" and auto-generate Visitor from nodes list.

### DIFF
--- a/odb-cli/include/odb-cli/AST.hpp
+++ b/odb-cli/include/odb-cli/AST.hpp
@@ -3,7 +3,7 @@
 #include "odb-cli/Actions.argdef.hpp"
 
 namespace odb::ast {
-class Block;
+class Program;
 }
 
 bool initCommandMatcher(const std::vector<std::string>& args);
@@ -14,4 +14,4 @@ bool dumpASTJSON(const std::vector<std::string>& args);
 ActionHandler parseDBPro(const std::vector<std::string>& args);
 ActionHandler autoDetectInput(const std::vector<std::string>& args);
 
-const odb::ast::Block* getAST();
+odb::ast::Program* getAST();

--- a/odb-cli/src/AST.cpp
+++ b/odb-cli/src/AST.cpp
@@ -1,6 +1,7 @@
 #include "odb-cli/AST.hpp"
 #include "odb-cli/Commands.hpp"
 #include "odb-compiler/ast/Block.hpp"
+#include "odb-compiler/ast/Program.hpp"
 #include "odb-compiler/ast/Exporters.hpp"
 #include "odb-compiler/parsers/db/Driver.hpp"
 #include "odb-compiler/commands/CommandMatcher.hpp"
@@ -9,7 +10,7 @@
 using namespace odb;
 
 static cmd::CommandMatcher cmdMatcher_;
-static Reference<ast::Block> ast_;
+static Reference<ast::Program> ast_;
 
 // ----------------------------------------------------------------------------
 bool initCommandMatcher(const std::vector<std::string>& args)
@@ -27,14 +28,14 @@ bool parseDBA(const std::vector<std::string>& args)
     for (const auto& arg : args)
     {
         Log::ast(Log::INFO, "Parsing file `%s`\n", arg.c_str());
-        Reference<ast::Block> block = driver.parse(arg, cmdMatcher_);
-        if (block == nullptr)
+        Reference<ast::Program> program = driver.parse(arg, cmdMatcher_);
+        if (program == nullptr)
             return false;
 
         if (ast_.isNull())
-            ast_ = block;
+            ast_ = program;
         else
-            ast_->merge(block);
+            ast_->body()->merge(program->body());
     }
 
     return true;
@@ -120,6 +121,6 @@ bool dumpASTJSON(const std::vector<std::string>& args)
 }
 
 // ----------------------------------------------------------------------------
-const odb::ast::Block* getAST() {
+odb::ast::Program* getAST() {
     return ast_;
 }

--- a/odb-cli/src/Codegen.cpp
+++ b/odb-cli/src/Codegen.cpp
@@ -2,6 +2,7 @@
 #include "odb-cli/AST.hpp"
 #include "odb-cli/Commands.hpp"
 #include "odb-cli/SDK.hpp"
+#include "odb-compiler/ast/Program.hpp"
 #include "odb-compiler/ir/Codegen.hpp"
 #include "odb-compiler/ir/Node.hpp"
 #include "odb-compiler/ir/SemanticChecker.hpp"
@@ -119,7 +120,7 @@ bool output(const std::vector<std::string>& args)
     odb::ir::TargetTriple targetTriple{*targetTripleArch_, *targetTriplePlatform_};
 
     // Run semantic checks and generate IR.
-    auto program = odb::ir::runSemanticChecks(ast, *cmdIndex);
+    auto program = odb::ir::runSemanticChecks(ast->body(), *cmdIndex);
     if (!program)
     {
         return false;

--- a/odb-compiler/CMakeLists.txt
+++ b/odb-compiler/CMakeLists.txt
@@ -204,6 +204,7 @@ add_library (odb-compiler ${ODBCOMPILER_LIB_TYPE}
     "src/ast/UDTField.cpp"
     "src/ast/UnaryOp.cpp"
     "src/ast/VarDecl.cpp"
+    "src/ast/Variable.cpp"
     "src/ast/VarRef.cpp"
     "src/ast/Visitor.cpp"
     "src/astpost/EliminateBitwiseNotRHS.cpp"

--- a/odb-compiler/CMakeLists.txt
+++ b/odb-compiler/CMakeLists.txt
@@ -184,6 +184,7 @@ add_library (odb-compiler ${ODBCOMPILER_LIB_TYPE}
     "src/ast/FuncDecl.cpp"
     "src/ast/Goto.cpp"
     "src/ast/Identifier.cpp"
+    "src/ast/ImplicitCast.cpp"
     "src/ast/InitializerList.cpp"
     "src/ast/Label.cpp"
     "src/ast/Literal.cpp"

--- a/odb-compiler/CMakeLists.txt
+++ b/odb-compiler/CMakeLists.txt
@@ -192,6 +192,7 @@ add_library (odb-compiler ${ODBCOMPILER_LIB_TYPE}
     "src/ast/Node.cpp"
     "src/ast/Operator.cpp"
     "src/ast/ParentMap.cpp"
+    "src/ast/Program.cpp"
     "src/ast/Scope.cpp"
     "src/ast/ScopedIdentifier.cpp"
     "src/ast/SelectCase.cpp"

--- a/odb-compiler/include/odb-compiler/ast/ArgList.hpp
+++ b/odb-compiler/include/odb-compiler/ast/ArgList.hpp
@@ -12,7 +12,7 @@ class ODBCOMPILER_PUBLIC_API ArgList final : public Node
 {
 public:
     ArgList(SourceLocation* location);
-    ArgList(Expression* expr, SourceLocation* location);
+    ArgList(Expression* initialExpr, SourceLocation* location);
 
     void appendExpression(Expression* expr);
 

--- a/odb-compiler/include/odb-compiler/ast/ArrayRef.hpp
+++ b/odb-compiler/include/odb-compiler/ast/ArrayRef.hpp
@@ -7,6 +7,7 @@ namespace odb::ast {
 
 class Identifier;
 class ArgList;
+class Variable;
 
 class ODBCOMPILER_PUBLIC_API ArrayRef final : public LValue
 {
@@ -15,6 +16,11 @@ public:
 
     Identifier* identifier() const;
     ArgList* args() const;
+
+    Type getType() const override;
+
+    void setVariable(Variable* variable);
+    Variable* variable() const;
 
     std::string toString() const override;
     void accept(Visitor* visitor) override;
@@ -28,6 +34,9 @@ protected:
 private:
     Reference<Identifier> identifier_;
     Reference<ArgList> args_;
+
+    // Resolved in a later pass.
+    Reference<Variable> variable_;
 };
 
 }

--- a/odb-compiler/include/odb-compiler/ast/BinaryOp.hpp
+++ b/odb-compiler/include/odb-compiler/ast/BinaryOp.hpp
@@ -15,6 +15,8 @@ public:
     Expression* lhs() const;
     Expression* rhs() const;
 
+    Type getType() const override;
+
     std::string toString() const override;
     void accept(Visitor* visitor) override;
     void accept(ConstVisitor* visitor) const override;

--- a/odb-compiler/include/odb-compiler/ast/CommandExpr.hpp
+++ b/odb-compiler/include/odb-compiler/ast/CommandExpr.hpp
@@ -16,11 +16,16 @@ class ArgList;
 class ODBCOMPILER_PUBLIC_API CommandExpr final : public Expression
 {
 public:
-    CommandExpr(const std::string& command, ArgList* args, SourceLocation* location);
-    CommandExpr(const std::string& command, SourceLocation* location);
+    CommandExpr(std::string commandName, ArgList* args, SourceLocation* location);
+    CommandExpr(std::string commandName, SourceLocation* location);
 
-    const std::string& command() const;
+    const std::string& commandName() const;
     MaybeNull<ArgList> args() const;
+
+    const cmd::Command* command() const;
+    void setCommand(const cmd::Command* command);
+
+    Type getType() const override;
 
     std::string toString() const override;
     void accept(Visitor* visitor) override;
@@ -32,8 +37,11 @@ protected:
     Node* duplicateImpl() const override;
 
 private:
+    const std::string commandName_;
     Reference<ArgList> args_;
-    const std::string command_;
+
+    // Resolved in a later pass.
+    const cmd::Command* command_;
 };
 
 }

--- a/odb-compiler/include/odb-compiler/ast/CommandStmnt.hpp
+++ b/odb-compiler/include/odb-compiler/ast/CommandStmnt.hpp
@@ -16,11 +16,14 @@ class ArgList;
 class ODBCOMPILER_PUBLIC_API CommandStmnt final : public Statement
 {
 public:
-    CommandStmnt(const std::string& command, ArgList* args, SourceLocation* location);
-    CommandStmnt(const std::string& command, SourceLocation* location);
+    CommandStmnt(std::string commandName, ArgList* args, SourceLocation* location);
+    CommandStmnt(std::string commandName, SourceLocation* location);
 
-    const std::string& command() const;
+    const std::string& commandName() const;
     MaybeNull<ArgList> args() const;
+
+    const cmd::Command* command() const;
+    void setCommand(const cmd::Command* command);
 
     std::string toString() const override;
     void accept(Visitor* visitor) override;
@@ -32,8 +35,11 @@ protected:
     Node* duplicateImpl() const override;
 
 private:
+    const std::string commandName_;
     Reference<ArgList> args_;
-    const std::string command_;
+
+    // Resolved in a later pass.
+    const cmd::Command* command_;
 };
 
 }

--- a/odb-compiler/include/odb-compiler/ast/Expression.hpp
+++ b/odb-compiler/include/odb-compiler/ast/Expression.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "odb-compiler/config.hpp"
+#include "odb-compiler/ast/Type.hpp"
 #include "odb-compiler/ast/Node.hpp"
+#include "odb-compiler/config.hpp"
 
 namespace odb::ast {
 
@@ -11,6 +12,8 @@ class ODBCOMPILER_PUBLIC_API Expression : public Node
 {
 public:
     Expression(SourceLocation* location);
+
+    virtual Type getType() const = 0;
 };
 
 }

--- a/odb-compiler/include/odb-compiler/ast/FuncCall.hpp
+++ b/odb-compiler/include/odb-compiler/ast/FuncCall.hpp
@@ -9,6 +9,7 @@ namespace odb::ast {
 
 class Identifier;
 class ArgList;
+class FuncDecl;
 
 class ODBCOMPILER_PUBLIC_API FuncCallExpr final : public Expression
 {
@@ -18,6 +19,11 @@ public:
 
     Identifier* identifier() const;
     MaybeNull<ArgList> args() const;
+
+    FuncDecl* function() const;
+    void setFunction(FuncDecl* func);
+
+    Type getType() const override;
 
     std::string toString() const override;
     void accept(Visitor* visitor) override;
@@ -31,6 +37,9 @@ protected:
 private:
     Reference<Identifier> identifier_;
     Reference<ArgList> args_;
+
+    // Resolved in a later pass.
+    FuncDecl* function_;
 };
 
 class ODBCOMPILER_PUBLIC_API FuncCallStmnt final : public Statement
@@ -42,6 +51,9 @@ public:
     Identifier* identifier() const;
     MaybeNull<ArgList> args() const;
 
+    FuncDecl* function() const;
+    void setFunction(FuncDecl* func);
+
     std::string toString() const override;
     void accept(Visitor* visitor) override;
     void accept(ConstVisitor* visitor) const override;
@@ -54,6 +66,9 @@ protected:
 private:
     Reference<Identifier> identifier_;
     Reference<ArgList> args_;
+
+    // Resolved in a later pass.
+    FuncDecl* function_;
 };
 
 /*!
@@ -62,7 +77,7 @@ private:
  *   foo(3, 4)
  *
  * is a function call or an array access. This class represents such an entity.
- * This is fixed in a second stage later.
+ * This is replaced with either a FuncCallExpr or ArrayRef in a later pass.
  */
 class ODBCOMPILER_PUBLIC_API FuncCallExprOrArrayRef final : public Expression
 {
@@ -71,6 +86,8 @@ public:
 
     Identifier* identifier() const;
     MaybeNull<ArgList> args() const;
+
+    Type getType() const override;
 
     std::string toString() const override;
     void accept(Visitor* visitor) override;

--- a/odb-compiler/include/odb-compiler/ast/ImplicitCast.hpp
+++ b/odb-compiler/include/odb-compiler/ast/ImplicitCast.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "odb-compiler/ast/Expression.hpp"
+#include "odb-compiler/ast/Type.hpp"
+
+namespace odb::ast {
+
+class ODBCOMPILER_PUBLIC_API ImplicitCast final : public Expression
+{
+public:
+    ImplicitCast(Expression* expr, Type targetType, SourceLocation* location);
+
+    Expression* expr() const;
+
+    Type getType() const override;
+
+    std::string toString() const override;
+    void accept(Visitor* visitor) override;
+    void accept(ConstVisitor* visitor) const override;
+    ChildRange children() override;
+    void swapChild(const Node* oldNode, Node* newNode) override;
+
+protected:
+    Node* duplicateImpl() const override;
+
+private:
+    Reference<Expression> expr_;
+    Type targetType_;
+};
+
+}

--- a/odb-compiler/include/odb-compiler/ast/InitializerList.hpp
+++ b/odb-compiler/include/odb-compiler/ast/InitializerList.hpp
@@ -18,6 +18,9 @@ public:
 
     const std::vector<Reference<Expression>>& expressions() const;
 
+    void setTypeBeingInitialized(Type typeBeingInitialized);
+    Type getType() const override;
+
     std::string toString() const override;
     void accept(Visitor* visitor) override;
     void accept(ConstVisitor* visitor) const override;
@@ -29,6 +32,7 @@ protected:
 
 private:
     std::vector<Reference<Expression>> expressions_;
+    Type typeBeingInitialized_;
 };
 
 }

--- a/odb-compiler/include/odb-compiler/ast/Literal.hpp
+++ b/odb-compiler/include/odb-compiler/ast/Literal.hpp
@@ -19,6 +19,8 @@ public:                                                                       \
     dbname##Literal(const cppname& value, SourceLocation* location);          \
     const cppname& value() const;                                             \
                                                                               \
+    Type getType() const override;                                            \
+                                                                              \
     std::string toString() const override;                                    \
     void accept(Visitor* visitor) override;                                   \
     void accept(ConstVisitor* visitor) const override;                        \

--- a/odb-compiler/include/odb-compiler/ast/Nodes.hpp
+++ b/odb-compiler/include/odb-compiler/ast/Nodes.hpp
@@ -48,6 +48,7 @@
     X(UnaryOp)                          \
     X(UntilLoop)                        \
     X(VarAssignment)                    \
+    X(Variable)                         \
     X(VarRef)                           \
     X(WhileLoop)                        \
     ODB_DATATYPE_LIST_IMPL(ODB_LITERAL_AST_NODE)

--- a/odb-compiler/include/odb-compiler/ast/Nodes.hpp
+++ b/odb-compiler/include/odb-compiler/ast/Nodes.hpp
@@ -31,6 +31,7 @@
     X(FuncExit)                         \
     X(Goto)                             \
     X(Identifier)                       \
+    X(ImplicitCast)                     \
     X(InfiniteLoop)                     \
     X(InitializerList)                  \
     X(Label)                            \

--- a/odb-compiler/include/odb-compiler/ast/Nodes.hpp
+++ b/odb-compiler/include/odb-compiler/ast/Nodes.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "odb-compiler/config.hpp"
+#include "odb-compiler/ast/Type.hpp"
+
+/*!
+ * @brief All of the DarkBASIC AST nodes
+ */
+#define ODB_LITERAL_AST_NODE(dbname, cppname) X(dbname##Literal)
+#define ODB_AST_NODE_TYPE_LIST_IMPL(X)  \
+    X(ArgList)                          \
+    X(ArrayAssignment)                  \
+    X(ArrayDecl)                        \
+    X(ArrayRef)                         \
+    X(BinaryOp)                         \
+    X(Block)                            \
+    X(Case)                             \
+    X(CaseList)                         \
+    X(CommandExpr)                      \
+    X(CommandStmnt)                     \
+    X(Conditional)                      \
+    X(ConstDecl)                        \
+    X(ConstDeclExpr)                    \
+    X(DefaultCase)                      \
+    X(Exit)                             \
+    X(ForLoop)                          \
+    X(FuncCallExpr)                     \
+    X(FuncCallExprOrArrayRef)           \
+    X(FuncCallStmnt)                    \
+    X(FuncDecl)                         \
+    X(FuncExit)                         \
+    X(Goto)                             \
+    X(Identifier)                       \
+    X(InfiniteLoop)                     \
+    X(InitializerList)                  \
+    X(Label)                            \
+    X(ScopedIdentifier)                 \
+    X(Select)                           \
+    X(SubCall)                          \
+    X(SubReturn)                        \
+    X(VarDecl)                          \
+    X(UDTDecl)                          \
+    X(UDTDeclBody)                      \
+    X(UDTFieldAssignment)               \
+    X(UDTFieldOuter)                    \
+    X(UDTFieldInner)                    \
+    X(UnaryOp)                          \
+    X(UntilLoop)                        \
+    X(VarAssignment)                    \
+    X(VarRef)                           \
+    X(WhileLoop)                        \
+    ODB_DATATYPE_LIST_IMPL(ODB_LITERAL_AST_NODE)
+
+#define ODB_AST_NODE_TYPE_LIST \
+    ODB_AST_NODE_TYPE_LIST_IMPL(X)

--- a/odb-compiler/include/odb-compiler/ast/Nodes.hpp
+++ b/odb-compiler/include/odb-compiler/ast/Nodes.hpp
@@ -34,6 +34,7 @@
     X(InfiniteLoop)                     \
     X(InitializerList)                  \
     X(Label)                            \
+    X(Program)                          \
     X(ScopedIdentifier)                 \
     X(Select)                           \
     X(SubCall)                          \

--- a/odb-compiler/include/odb-compiler/ast/Program.hpp
+++ b/odb-compiler/include/odb-compiler/ast/Program.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "odb-compiler/config.hpp"
+#include "odb-compiler/ast/Statement.hpp"
+
+namespace odb::ast {
+
+class Block;
+class Expression;
+
+class ODBCOMPILER_PUBLIC_API Program final : public Node
+{
+public:
+    Program(Block* body, SourceLocation* location);
+
+    Block* body() const;
+
+    std::string toString() const override;
+    void accept(Visitor* visitor) override;
+    void accept(ConstVisitor* visitor) const override;
+    ChildRange children() override;
+    void swapChild(const Node* oldNode, Node* newNode) override;
+
+protected:
+    Node* duplicateImpl() const override;
+
+private:
+    Reference<Block> body_;
+};
+
+}

--- a/odb-compiler/include/odb-compiler/ast/Type.hpp
+++ b/odb-compiler/include/odb-compiler/ast/Type.hpp
@@ -13,7 +13,7 @@
  * @brief All of the DarkBASIC primitive types that can exist and what types
  * they map to in C++
  */
-#define ODB_DATATYPE_LIST                       \
+#define ODB_DATATYPE_LIST_IMPL(X)               \
     X(DoubleInteger, int64_t)                   \
     X(Integer,       int32_t)                   \
     X(Dword,         uint32_t)                  \
@@ -37,6 +37,9 @@
     X(Vec2,          odb::ast::Vec2<float>)     \
     X(Vec3,          odb::ast::Vec3<float>)     \
     X(Vec4,          odb::ast::Vec4<float>)
+
+#define ODB_DATATYPE_LIST \
+    ODB_DATATYPE_LIST_IMPL(X)
 
 namespace odb::ast {
 

--- a/odb-compiler/include/odb-compiler/ast/Type.hpp
+++ b/odb-compiler/include/odb-compiler/ast/Type.hpp
@@ -87,6 +87,7 @@ ODB_DATATYPE_LIST
 class ODBCOMPILER_PUBLIC_API Type
 {
 public:
+    static Type getUnknown();
     static Type getVoid();
     static Type getBuiltin(BuiltinType builtin);
     static Type getUDT(std::string name);
@@ -94,6 +95,7 @@ public:
     static Type getFromAnnotation(ast::Annotation annotation);
     static Type getFromCommandType(cmd::Command::Type commandType);
 
+    bool isUnknown() const;
     bool isVoid() const;
     bool isBuiltinType() const;
     bool isUDT() const;
@@ -113,6 +115,7 @@ public:
     bool operator!=(const Type& other) const;
 
 private:
+    struct UnknownType {};
     struct VoidType {};
     struct UDTType { std::string udt; };
     struct ArrayType
@@ -124,7 +127,7 @@ private:
         std::unique_ptr<Type> inner;
     };
 
-    using TypeVariant = std::variant<VoidType, BuiltinType, UDTType, ArrayType>;
+    using TypeVariant = std::variant<UnknownType, VoidType, BuiltinType, UDTType, ArrayType>;
 
     explicit Type(TypeVariant variant);
 

--- a/odb-compiler/include/odb-compiler/ast/UDTField.hpp
+++ b/odb-compiler/include/odb-compiler/ast/UDTField.hpp
@@ -13,6 +13,8 @@ public:
     Expression* left() const;
     LValue* right() const;
 
+    Type getType() const override;
+
     std::string toString() const override;
     void accept(Visitor* visitor) override;
     void accept(ConstVisitor* visitor) const override;
@@ -34,6 +36,8 @@ public:
 
     LValue* left() const;
     LValue* right() const;
+
+    Type getType() const override;
 
     std::string toString() const override;
     void accept(Visitor* visitor) override;

--- a/odb-compiler/include/odb-compiler/ast/UnaryOp.hpp
+++ b/odb-compiler/include/odb-compiler/ast/UnaryOp.hpp
@@ -14,6 +14,8 @@ public:
     UnaryOpType op() const;
     Expression* expr() const;
 
+    Type getType() const override;
+
     std::string toString() const override;
     void accept(Visitor* visitor) override;
     void accept(ConstVisitor* visitor) const override;

--- a/odb-compiler/include/odb-compiler/ast/VarRef.hpp
+++ b/odb-compiler/include/odb-compiler/ast/VarRef.hpp
@@ -7,6 +7,7 @@ namespace odb {
 namespace ast {
 
 class Identifier;
+class Variable;
 
 class ODBCOMPILER_PUBLIC_API VarRef final : public LValue
 {
@@ -14,6 +15,11 @@ public:
     VarRef(Identifier* identifier, SourceLocation* location);
 
     Identifier* identifier() const;
+
+    Type getType() const override;
+
+    void setVariable(Variable* variable);
+    Variable* variable() const;
 
     std::string toString() const override;
     void accept(Visitor* visitor) override;
@@ -26,6 +32,9 @@ protected:
 
 private:
     Reference<Identifier> identifier_;
+
+    // Resolved in a later pass.
+    Reference<Variable> variable_;
 };
 
 }

--- a/odb-compiler/include/odb-compiler/ast/Variable.hpp
+++ b/odb-compiler/include/odb-compiler/ast/Variable.hpp
@@ -1,19 +1,22 @@
 #pragma once
 
 #include "odb-compiler/config.hpp"
-#include "odb-compiler/ast/Node.hpp"
 #include "odb-compiler/ast/Annotation.hpp"
+#include "odb-compiler/ast/SourceLocation.hpp"
+#include "odb-compiler/ast/Type.hpp"
+#include "odb-compiler/ast/Node.hpp"
 
 namespace odb::ast {
 
-class ODBCOMPILER_PUBLIC_API Identifier : public Node
+class ODBCOMPILER_PUBLIC_API Variable final : public Node
 {
 public:
-    Identifier(std::string name, SourceLocation* location);
-    Identifier(std::string name, Annotation annotation, SourceLocation* location);
+    Variable(SourceLocation* location, std::string name, Type type);
+    Variable(SourceLocation* location, std::string name, Annotation annotation, Type type);
 
     const std::string& name() const;
     Annotation annotation() const;
+    Type type() const;
 
     std::string toString() const override;
     void accept(Visitor* visitor) override;
@@ -24,9 +27,9 @@ public:
 protected:
     Node* duplicateImpl() const override;
 
-protected:
     const std::string name_;
     Annotation annotation_;
+    Type type_;
 };
 
 }

--- a/odb-compiler/include/odb-compiler/ast/Visitor.hpp
+++ b/odb-compiler/include/odb-compiler/ast/Visitor.hpp
@@ -2,56 +2,14 @@
 
 #include "odb-compiler/config.hpp"
 #include "odb-compiler/ast/Type.hpp"
+#include "odb-compiler/ast/Nodes.hpp"
 
 namespace odb::ast {
 
 class Node;
 
-class ArgList;
-class ArrayAssignment;
-class ArrayDecl;
-class ArrayRef;
-class BinaryOp;
-class Block;
-class Case;
-class CaseList;
-class Exit;
-class CommandExpr;
-class CommandStmnt;
-class Conditional;
-class ConstDecl;
-class ConstDeclExpr;
-class DefaultCase;
-class ForLoop;
-class FuncCallExpr;
-class FuncCallExprOrArrayRef;
-class FuncCallStmnt;
-class FuncDecl;
-class FuncExit;
-class Goto;
-class Identifier;
-class InfiniteLoop;
-class InitializerList;
-class Label;
-class ScopedIdentifier;
-class Select;
-class SubCall;
-class SubReturn;
-class VarDecl;
-class UDTDecl;
-class UDTDeclBody;
-class UDTFieldOuter;
-class UDTFieldInner;
-class UDTFieldAssignment;
-class UnaryOp;
-class UntilLoop;
-class VarAssignment;
-class VarRef;
-class WhileLoop;
-
-#define X(dbname, cppname) \
-    class dbname##Literal;
-ODB_DATATYPE_LIST
+#define X(nodeType) class nodeType;
+ODB_AST_NODE_TYPE_LIST
 #undef X
 
 class ODBCOMPILER_PUBLIC_API Visitor
@@ -59,51 +17,8 @@ class ODBCOMPILER_PUBLIC_API Visitor
 public:
     virtual ~Visitor() = default;
 
-    virtual void visitArgList(ArgList* node) = 0;
-    virtual void visitArrayAssignment(ArrayAssignment* node) = 0;
-    virtual void visitArrayDecl(ArrayDecl* node) = 0;
-    virtual void visitArrayRef(ArrayRef* node) = 0;
-    virtual void visitBinaryOp(BinaryOp* node) = 0;
-    virtual void visitBlock(Block* node) = 0;
-    virtual void visitCase(Case* node) = 0;
-    virtual void visitCaseList(CaseList* node) = 0;
-    virtual void visitCommandExpr(CommandExpr* node) = 0;
-    virtual void visitCommandStmnt(CommandStmnt* node) = 0;
-    virtual void visitConditional(Conditional* node) = 0;
-    virtual void visitConstDecl(ConstDecl* node) = 0;
-    virtual void visitConstDeclExpr(ConstDeclExpr* node) = 0;
-    virtual void visitDefaultCase(DefaultCase* node) = 0;
-    virtual void visitExit(Exit* node) = 0;
-    virtual void visitForLoop(ForLoop* node) = 0;
-    virtual void visitFuncCallExpr(FuncCallExpr* node) = 0;
-    virtual void visitFuncCallExprOrArrayRef(FuncCallExprOrArrayRef* node)  = 0;
-    virtual void visitFuncCallStmnt(FuncCallStmnt* node) = 0;
-    virtual void visitFuncDecl(FuncDecl* node) = 0;
-    virtual void visitFuncExit(FuncExit* node) = 0;
-    virtual void visitGoto(Goto* node) = 0;
-    virtual void visitIdentifier(Identifier* node) = 0;
-    virtual void visitInfiniteLoop(InfiniteLoop* node) = 0;
-    virtual void visitInitializerList(InitializerList* node) = 0;
-    virtual void visitLabel(Label* node) = 0;
-    virtual void visitScopedIdentifier(ScopedIdentifier* node) = 0;
-    virtual void visitSelect(Select* node) = 0;
-    virtual void visitSubCall(SubCall* node) = 0;
-    virtual void visitSubReturn(SubReturn* node) = 0;
-    virtual void visitVarDecl(VarDecl* node) = 0;
-    virtual void visitUDTDecl(UDTDecl* node) = 0;
-    virtual void visitUDTDeclBody(UDTDeclBody* node) = 0;
-    virtual void visitUDTFieldAssignment(UDTFieldAssignment* node) = 0;
-    virtual void visitUDTFieldOuter(UDTFieldOuter* node) = 0;
-    virtual void visitUDTFieldInner(UDTFieldInner* node) = 0;
-    virtual void visitUnaryOp(UnaryOp* node) = 0;
-    virtual void visitUntilLoop(UntilLoop* node) = 0;
-    virtual void visitVarAssignment(VarAssignment* node) = 0;
-    virtual void visitVarRef(VarRef* node) = 0;
-    virtual void visitWhileLoop(WhileLoop* node) = 0;
-
-#define X(dbname, cppname) \
-    virtual void visit##dbname##Literal(dbname##Literal* node) = 0;
-    ODB_DATATYPE_LIST
+#define X(nodeType) virtual void visit##nodeType(nodeType* node) = 0;
+    ODB_AST_NODE_TYPE_LIST
 #undef X
 };
 
@@ -112,102 +27,16 @@ class ODBCOMPILER_PUBLIC_API ConstVisitor
 public:
     virtual ~ConstVisitor() = default;
 
-    virtual void visitArgList(const ArgList* node) = 0;
-    virtual void visitArrayAssignment(const ArrayAssignment* node) = 0;
-    virtual void visitArrayDecl(const ArrayDecl* node) = 0;
-    virtual void visitArrayRef(const ArrayRef* node)  = 0;
-    virtual void visitBinaryOp(const BinaryOp* node) = 0;
-    virtual void visitBlock(const Block* node) = 0;
-    virtual void visitCase(const Case* node) = 0;
-    virtual void visitCaseList(const CaseList* node) = 0;
-    virtual void visitCommandExpr(const CommandExpr* node) = 0;
-    virtual void visitCommandStmnt(const CommandStmnt* node) = 0;
-    virtual void visitConditional(const Conditional* node) = 0;
-    virtual void visitConstDecl(const ConstDecl* node) = 0;
-    virtual void visitConstDeclExpr(const ConstDeclExpr* node) = 0;
-    virtual void visitDefaultCase(const DefaultCase* node) = 0;
-    virtual void visitExit(const Exit* node) = 0;
-    virtual void visitForLoop(const ForLoop* node) = 0;
-    virtual void visitFuncCallExpr(const FuncCallExpr* node) = 0;
-    virtual void visitFuncCallExprOrArrayRef(const FuncCallExprOrArrayRef* node)  = 0;
-    virtual void visitFuncCallStmnt(const FuncCallStmnt* node) = 0;
-    virtual void visitFuncDecl(const FuncDecl* node) = 0;
-    virtual void visitFuncExit(const FuncExit* node) = 0;
-    virtual void visitGoto(const Goto* node) = 0;
-    virtual void visitIdentifier(const Identifier* node) = 0;
-    virtual void visitInfiniteLoop(const InfiniteLoop* node) = 0;
-    virtual void visitInitializerList(const InitializerList* node) = 0;
-    virtual void visitLabel(const Label* node) = 0;
-    virtual void visitScopedIdentifier(const ScopedIdentifier* node) = 0;
-    virtual void visitSelect(const Select* node) = 0;
-    virtual void visitSubCall(const SubCall* node) = 0;
-    virtual void visitSubReturn(const SubReturn* node) = 0;
-    virtual void visitVarDecl(const VarDecl* node) = 0;
-    virtual void visitUDTDecl(const UDTDecl* node) = 0;
-    virtual void visitUDTDeclBody(const UDTDeclBody* node) = 0;
-    virtual void visitUDTFieldAssignment(const UDTFieldAssignment* node) = 0;
-    virtual void visitUDTFieldOuter(const UDTFieldOuter* node) = 0;
-    virtual void visitUDTFieldInner(const UDTFieldInner* node) = 0;
-    virtual void visitUnaryOp(const UnaryOp* node) = 0;
-    virtual void visitUntilLoop(const UntilLoop* node) = 0;
-    virtual void visitVarAssignment(const VarAssignment* node) = 0;
-    virtual void visitVarRef(const VarRef* node) = 0;
-    virtual void visitWhileLoop(const WhileLoop* node) = 0;
-
-#define X(dbname, cppname) \
-    virtual void visit##dbname##Literal(const dbname##Literal* node) = 0;
-    ODB_DATATYPE_LIST
+#define X(nodeType) virtual void visit##nodeType(const nodeType* node) = 0;
+    ODB_AST_NODE_TYPE_LIST
 #undef X
 };
 
 class ODBCOMPILER_PUBLIC_API GenericVisitor : public Visitor
 {
 public:
-    void visitArgList(ArgList* node) override;
-    void visitArrayAssignment(ArrayAssignment* node) override;
-    void visitArrayDecl(ArrayDecl* node) override;
-    void visitArrayRef(ArrayRef* node) override;
-    void visitBinaryOp(BinaryOp* node) override;
-    void visitBlock(Block* node) override;
-    void visitCase(Case* node) override;
-    void visitCaseList(CaseList* node) override;
-    void visitCommandExpr(CommandExpr* node) override;
-    void visitCommandStmnt(CommandStmnt* node) override;
-    void visitConditional(Conditional* node) override;
-    void visitConstDecl(ConstDecl* node) override;
-    void visitConstDeclExpr(ConstDeclExpr* node) override;
-    void visitDefaultCase(DefaultCase* node) override;
-    void visitExit(Exit* node) override;
-    void visitForLoop(ForLoop* node) override;
-    void visitFuncCallExpr(FuncCallExpr* node) override;
-    void visitFuncCallExprOrArrayRef(FuncCallExprOrArrayRef* node) override;
-    void visitFuncCallStmnt(FuncCallStmnt* node) override;
-    void visitFuncDecl(FuncDecl* node) override;
-    void visitFuncExit(FuncExit* node) override;
-    void visitGoto(Goto* node) override;
-    void visitIdentifier(Identifier* node) override;
-    void visitInfiniteLoop(InfiniteLoop* node) override;
-    void visitInitializerList(InitializerList* node) override;
-    void visitLabel(Label* node) override;
-    void visitScopedIdentifier(ScopedIdentifier* node) override;
-    void visitSelect(Select* node) override;
-    void visitSubCall(SubCall* node) override;
-    void visitSubReturn(SubReturn* node) override;
-    void visitVarDecl(VarDecl* node) override;
-    void visitUDTDecl(UDTDecl* node) override;
-    void visitUDTDeclBody(UDTDeclBody* node) override;
-    void visitUDTFieldAssignment(UDTFieldAssignment* node) override;
-    void visitUDTFieldOuter(UDTFieldOuter* node) override;
-    void visitUDTFieldInner(UDTFieldInner* node) override;
-    void visitUnaryOp(UnaryOp* node) override;
-    void visitUntilLoop(UntilLoop* node) override;
-    void visitVarAssignment(VarAssignment* node) override;
-    void visitVarRef(VarRef* node) override;
-    void visitWhileLoop(WhileLoop* node) override;
-
-#define X(dbname, cppname) \
-    void visit##dbname##Literal(dbname##Literal* node) override;
-    ODB_DATATYPE_LIST
+#define X(nodeType) void visit##nodeType(nodeType* node) override;
+    ODB_AST_NODE_TYPE_LIST
 #undef X
 
     virtual void visit(Node* node) = 0;
@@ -216,51 +45,8 @@ public:
 class ODBCOMPILER_PUBLIC_API GenericConstVisitor : public ConstVisitor
 {
 public:
-    void visitArgList(const ArgList* node) override;
-    void visitArrayAssignment(const ArrayAssignment* node) override;
-    void visitArrayDecl(const ArrayDecl* node) override;
-    void visitArrayRef(const ArrayRef* node) override;
-    void visitBinaryOp(const BinaryOp* node) override;
-    void visitBlock(const Block* node) override;
-    void visitCase(const Case* node) override;
-    void visitCaseList(const CaseList* node) override;
-    void visitCommandExpr(const CommandExpr* node) override;
-    void visitCommandStmnt(const CommandStmnt* node) override;
-    void visitConditional(const Conditional* node) override;
-    void visitConstDecl(const ConstDecl* node) override;
-    void visitConstDeclExpr(const ConstDeclExpr* node) override;
-    void visitDefaultCase(const DefaultCase* node) override;
-    void visitExit(const Exit* node) override;
-    void visitForLoop(const ForLoop* node) override;
-    void visitFuncCallExpr(const FuncCallExpr* node) override;
-    void visitFuncCallExprOrArrayRef(const FuncCallExprOrArrayRef* node) override;
-    void visitFuncCallStmnt(const FuncCallStmnt* node) override;
-    void visitFuncDecl(const FuncDecl* node) override;
-    void visitFuncExit(const FuncExit* node) override;
-    void visitGoto(const Goto* node) override;
-    void visitIdentifier(const Identifier* node) override;
-    void visitInfiniteLoop(const InfiniteLoop* node) override;
-    void visitInitializerList(const InitializerList* node) override;
-    void visitLabel(const Label* node) override;
-    void visitScopedIdentifier(const ScopedIdentifier* node) override;
-    void visitSelect(const Select* node) override;
-    void visitSubCall(const SubCall* node) override;
-    void visitSubReturn(const SubReturn* node) override;
-    void visitVarDecl(const VarDecl* node) override;
-    void visitUDTDecl(const UDTDecl* node) override;
-    void visitUDTDeclBody(const UDTDeclBody* node) override;
-    void visitUDTFieldOuter(const UDTFieldOuter* node) override;
-    void visitUDTFieldInner(const UDTFieldInner* node) override;
-    void visitUDTFieldAssignment(const UDTFieldAssignment* node) override;
-    void visitUnaryOp(const UnaryOp* node) override;
-    void visitUntilLoop(const UntilLoop* node) override;
-    void visitVarAssignment(const VarAssignment* node) override;
-    void visitVarRef(const VarRef* node) override;
-    void visitWhileLoop(const WhileLoop* node) override;
-
-#define X(dbname, cppname) \
-    void visit##dbname##Literal(const dbname##Literal* node) override;
-    ODB_DATATYPE_LIST
+#define X(nodeType) void visit##nodeType(const nodeType* node) override;
+    ODB_AST_NODE_TYPE_LIST
 #undef X
 
     virtual void visit(const Node* node) = 0;

--- a/odb-compiler/include/odb-compiler/parsers/db/Driver.hpp
+++ b/odb-compiler/include/odb-compiler/parsers/db/Driver.hpp
@@ -11,7 +11,7 @@ namespace odb {
 namespace ast {
     class ArrayRef;
     class Assignment;
-    class Block;
+    class Program;
     class Expression;
     class Literal;
     class SourceLocation;
@@ -44,7 +44,7 @@ public:
      * It's not possible to retrieve the root node from the dbpush_parse() so
      * we instead have bison pass in the root node to the driver
      */
-    ODBCOMPILER_PRIVATE_API void giveProgram(ast::Block* program);
+    ODBCOMPILER_PRIVATE_API void giveProgram(ast::Program* program);
 
     /*!
      * Attempts to create the smallest possible literal type based on the value
@@ -82,16 +82,16 @@ public:
     // ------------------------------------------------------------------------
 
 protected:
-    ast::Block* doParse(dbscan_t scanner, dbpstate* parser, const cmd::CommandMatcher& commandMatcher);
+    ast::Program* doParse(dbscan_t scanner, dbpstate* parser, const cmd::CommandMatcher& commandMatcher);
 
 private:
-    odb::Reference<ast::Block> program_;
+    odb::Reference<ast::Program> program_;
 };
 
 class ODBCOMPILER_PUBLIC_API FileParserDriver : public Driver
 {
 public:
-    ast::Block* parse(const std::string& fileName, const cmd::CommandMatcher& commandMatcher);
+    ast::Program* parse(const std::string& fileName, const cmd::CommandMatcher& commandMatcher);
 
 protected:
     virtual ast::SourceLocation* newLocation(const DBLTYPE* loc) const override;
@@ -103,7 +103,7 @@ private:
 class ODBCOMPILER_PUBLIC_API StringParserDriver : public Driver
 {
 public:
-    ast::Block* parse(const std::string& sourceName, const std::string& str, const cmd::CommandMatcher& commandMatcher);
+    ast::Program* parse(const std::string& sourceName, const std::string& str, const cmd::CommandMatcher& commandMatcher);
 
 protected:
     virtual ast::SourceLocation* newLocation(const DBLTYPE* loc) const override;

--- a/odb-compiler/src/ast/ArrayRef.cpp
+++ b/odb-compiler/src/ast/ArrayRef.cpp
@@ -2,14 +2,17 @@
 #include "odb-compiler/ast/ArgList.hpp"
 #include "odb-compiler/ast/Identifier.hpp"
 #include "odb-compiler/ast/SourceLocation.hpp"
+#include "odb-compiler/ast/Variable.hpp"
 #include "odb-compiler/ast/Visitor.hpp"
 
 namespace odb::ast {
 
 // ----------------------------------------------------------------------------
 ArrayRef::ArrayRef(Identifier* identifier, ArgList* args, SourceLocation* location) :
-    LValue(location), identifier_(identifier),
-    args_(args)
+    LValue(location),
+    identifier_(identifier),
+    args_(args),
+    variable_(nullptr)
 {
 }
 
@@ -23,6 +26,26 @@ Identifier* ArrayRef::identifier() const
 ArgList* ArrayRef::args() const
 {
     return args_;
+}
+
+// ----------------------------------------------------------------------------
+Type ArrayRef::getType() const
+{
+    return variable_ ? variable_->type() : Type::getUnknown();
+}
+
+// ----------------------------------------------------------------------------
+void ArrayRef::setVariable(Variable* variable)
+{
+    assert(identifier_->name() == variable->name());
+    variable_ = variable;
+}
+
+// ----------------------------------------------------------------------------
+Variable* ArrayRef::variable() const
+{
+    assert(identifier_->name() == variable_->name());
+    return variable_;
 }
 
 // ----------------------------------------------------------------------------

--- a/odb-compiler/src/ast/BinaryOp.cpp
+++ b/odb-compiler/src/ast/BinaryOp.cpp
@@ -32,6 +32,21 @@ Expression* BinaryOp::rhs() const
 }
 
 // ----------------------------------------------------------------------------
+Type BinaryOp::getType() const
+{
+    if (lhs_->getType() == rhs_->getType())
+    {
+        // Types should've been unified by adding implicit casts.
+        return lhs_->getType();
+    }
+    else
+    {
+        // Until we've unified the types, we don't know which is the right one.
+        return Type::getUnknown();
+    }
+}
+
+// ----------------------------------------------------------------------------
 std::string BinaryOp::toString() const
 {
     return std::string("BinaryOp(") + binaryOpTypeEnumString(op_) + ")";

--- a/odb-compiler/src/ast/Exporters_DOT.cpp
+++ b/odb-compiler/src/ast/Exporters_DOT.cpp
@@ -29,6 +29,7 @@
 #include "odb-compiler/ast/UDTField.hpp"
 #include "odb-compiler/ast/UnaryOp.hpp"
 #include "odb-compiler/ast/VarDecl.hpp"
+#include "odb-compiler/ast/Variable.hpp"
 #include "odb-compiler/ast/VarRef.hpp"
 #include "odb-compiler/ast/Visitor.hpp"
 #include "odb-compiler/commands/Command.hpp"
@@ -289,6 +290,7 @@ private:
         writeNamedConnection(node, node->variable(), "var");
         writeNamedConnection(node, node->expression(), "expr");
     }
+    void visitVariable(const Variable* node) override {}
     void visitVarRef(const VarRef* node) override
     {
         writeNamedConnection(node, node->identifier(), "identifier");

--- a/odb-compiler/src/ast/Exporters_DOT.cpp
+++ b/odb-compiler/src/ast/Exporters_DOT.cpp
@@ -19,6 +19,7 @@
 #include "odb-compiler/ast/Literal.hpp"
 #include "odb-compiler/ast/Loop.hpp"
 #include "odb-compiler/ast/Node.hpp"
+#include "odb-compiler/ast/Program.hpp"
 #include "odb-compiler/ast/ScopedIdentifier.hpp"
 #include "odb-compiler/ast/SelectCase.hpp"
 #include "odb-compiler/ast/SourceLocation.hpp"
@@ -220,6 +221,10 @@ private:
     void visitLabel(const Label* node) override
     {
         writeNamedConnection(node, node->identifier(), "identifier");
+    }
+    void visitProgram(const Program* node) override
+    {
+        writeNamedConnection(node, node->body(), "body");
     }
     void visitScopedIdentifier(const ScopedIdentifier* node) override {}
     void visitSelect(const Select* node) override

--- a/odb-compiler/src/ast/Exporters_DOT.cpp
+++ b/odb-compiler/src/ast/Exporters_DOT.cpp
@@ -14,6 +14,7 @@
 #include "odb-compiler/ast/FuncDecl.hpp"
 #include "odb-compiler/ast/Goto.hpp"
 #include "odb-compiler/ast/Identifier.hpp"
+#include "odb-compiler/ast/ImplicitCast.hpp"
 #include "odb-compiler/ast/InitializerList.hpp"
 #include "odb-compiler/ast/Label.hpp"
 #include "odb-compiler/ast/Literal.hpp"
@@ -206,6 +207,10 @@ private:
         writeNamedConnection(node, node->label(), "label");
     }
     void visitIdentifier(const Identifier* node) override {}
+    void visitImplicitCast(const ImplicitCast* node) override
+    {
+        writeNamedConnection(node, node->expr(), "expr");
+    }
     void visitInfiniteLoop(const InfiniteLoop* node) override
     {
         if (node->body().notNull())

--- a/odb-compiler/src/ast/ImplicitCast.cpp
+++ b/odb-compiler/src/ast/ImplicitCast.cpp
@@ -1,0 +1,67 @@
+#include "odb-compiler/ast/ImplicitCast.hpp"
+#include "odb-compiler/ast/SourceLocation.hpp"
+#include "odb-compiler/ast/Visitor.hpp"
+
+namespace odb::ast {
+
+// ----------------------------------------------------------------------------
+ImplicitCast::ImplicitCast(Expression* expr, Type targetType, SourceLocation* location) :
+    Expression(location),
+    expr_(expr),
+    targetType_(targetType)
+{
+}
+
+// ----------------------------------------------------------------------------
+Expression* ImplicitCast::expr() const
+{
+    return expr_;
+}
+
+// ----------------------------------------------------------------------------
+Type ImplicitCast::getType() const
+{
+    return targetType_;
+}
+
+// ----------------------------------------------------------------------------
+std::string ImplicitCast::toString() const
+{
+    return "ImplicitCast";
+}
+
+// ----------------------------------------------------------------------------
+void ImplicitCast::accept(Visitor* visitor)
+{
+    visitor->visitImplicitCast(this);
+}
+void ImplicitCast::accept(ConstVisitor* visitor) const
+{
+    visitor->visitImplicitCast(this);
+}
+
+// ----------------------------------------------------------------------------
+Node::ChildRange ImplicitCast::children()
+{
+    return {expr_};
+}
+
+// ----------------------------------------------------------------------------
+void ImplicitCast::swapChild(const Node* oldNode, Node* newNode)
+{
+    if (expr_ == oldNode)
+        expr_ = dynamic_cast<Expression*>(newNode);
+    else
+        assert(false);
+}
+
+// ----------------------------------------------------------------------------
+Node* ImplicitCast::duplicateImpl() const
+{
+    return new ImplicitCast(
+        expr_->duplicate<Expression>(),
+        targetType_,
+        location());
+}
+
+}

--- a/odb-compiler/src/ast/InitializerList.cpp
+++ b/odb-compiler/src/ast/InitializerList.cpp
@@ -7,13 +7,15 @@ namespace odb::ast {
 
 // ----------------------------------------------------------------------------
 InitializerList::InitializerList(SourceLocation* location) :
-    Expression(location)
+    Expression(location),
+    typeBeingInitialized_(Type::getUnknown())
 {
 }
 
 // ----------------------------------------------------------------------------
 InitializerList::InitializerList(Expression* expr, SourceLocation* location) :
-    Expression(location)
+    Expression(location),
+    typeBeingInitialized_(Type::getUnknown())
 {
     appendExpression(expr);
 }
@@ -30,6 +32,16 @@ void InitializerList::appendExpression(Expression* expr)
 const std::vector<Reference<Expression>>& InitializerList::expressions() const
 {
     return expressions_;
+}
+
+void InitializerList::setTypeBeingInitialized(Type typeBeingInitialized)
+{
+    typeBeingInitialized_ = typeBeingInitialized;
+}
+
+Type InitializerList::getType() const
+{
+    return typeBeingInitialized_;
 }
 
 // ----------------------------------------------------------------------------

--- a/odb-compiler/src/ast/Literal.cpp
+++ b/odb-compiler/src/ast/Literal.cpp
@@ -66,6 +66,11 @@ Literal::Literal(SourceLocation* location) :
         return value_;                                                        \
     }                                                                         \
                                                                               \
+    Type dbname##Literal::getType() const                                     \
+    {                                                                         \
+        return Type::getBuiltin(BuiltinType::dbname);                         \
+    }                                                                         \
+                                                                              \
     std::string dbname##Literal::toString() const                             \
     {                                                                         \
         return dbname##_STR;                                                  \

--- a/odb-compiler/src/ast/Program.cpp
+++ b/odb-compiler/src/ast/Program.cpp
@@ -1,0 +1,60 @@
+#include "odb-compiler/ast/Program.hpp"
+#include "odb-compiler/ast/Block.hpp"
+#include "odb-compiler/ast/SourceLocation.hpp"
+#include "odb-compiler/ast/Visitor.hpp"
+
+namespace odb::ast {
+
+// ----------------------------------------------------------------------------
+Program::Program(Block* body, SourceLocation* location) :
+    Node(location),
+    body_(body)
+{
+}
+
+// ----------------------------------------------------------------------------
+Block* Program::body() const
+{
+    return body_.get();
+}
+
+// ----------------------------------------------------------------------------
+std::string Program::toString() const
+{
+    return "Program";
+}
+
+// ----------------------------------------------------------------------------
+void Program::accept(Visitor* visitor)
+{
+    visitor->visitProgram(this);
+}
+void Program::accept(ConstVisitor* visitor) const
+{
+    visitor->visitProgram(this);
+}
+
+// ----------------------------------------------------------------------------
+Node::ChildRange Program::children()
+{
+    return {body_.get()};
+}
+
+// ----------------------------------------------------------------------------
+void Program::swapChild(const Node* oldNode, Node* newNode)
+{
+    if (body_ == oldNode)
+        body_ = dynamic_cast<Block*>(newNode);
+    else
+        assert(false);
+}
+
+// ----------------------------------------------------------------------------
+Node* Program::duplicateImpl() const
+{
+    return new Program(
+        body_->duplicate<Block>(),
+        location());
+}
+
+}

--- a/odb-compiler/src/ast/UDTField.cpp
+++ b/odb-compiler/src/ast/UDTField.cpp
@@ -24,6 +24,13 @@ LValue* UDTFieldOuter::right() const
 }
 
 // ----------------------------------------------------------------------------
+Type UDTFieldOuter::getType() const
+{
+    // TODO: Implement.
+    return Type::getUnknown();
+}
+
+// ----------------------------------------------------------------------------
 std::string UDTFieldOuter::toString() const
 {
     return "UDTFieldOuter";
@@ -86,6 +93,13 @@ LValue* UDTFieldInner::left() const
 LValue* UDTFieldInner::right() const
 {
     return right_;
+}
+
+// ----------------------------------------------------------------------------
+Type UDTFieldInner::getType() const
+{
+    // TODO: Implement.
+    return Type::getUnknown();
 }
 
 // ----------------------------------------------------------------------------

--- a/odb-compiler/src/ast/UnaryOp.cpp
+++ b/odb-compiler/src/ast/UnaryOp.cpp
@@ -25,6 +25,12 @@ Expression* UnaryOp::expr() const
 }
 
 // ----------------------------------------------------------------------------
+Type UnaryOp::getType() const
+{
+    return expr_->getType();
+}
+
+// ----------------------------------------------------------------------------
 std::string UnaryOp::toString() const
 {
     return std::string("UnaryOp(") + unaryOpTypeEnumString(op_) + ")";

--- a/odb-compiler/src/ast/VarRef.cpp
+++ b/odb-compiler/src/ast/VarRef.cpp
@@ -1,6 +1,7 @@
 #include "odb-compiler/ast/VarRef.hpp"
 #include "odb-compiler/ast/Identifier.hpp"
 #include "odb-compiler/ast/SourceLocation.hpp"
+#include "odb-compiler/ast/Variable.hpp"
 #include "odb-compiler/ast/Visitor.hpp"
 
 namespace odb::ast {
@@ -8,7 +9,8 @@ namespace odb::ast {
 // ----------------------------------------------------------------------------
 VarRef::VarRef(Identifier* identifier, SourceLocation* location) :
     LValue(location),
-    identifier_(identifier)
+    identifier_(identifier),
+    variable_(nullptr)
 {
 }
 
@@ -16,6 +18,26 @@ VarRef::VarRef(Identifier* identifier, SourceLocation* location) :
 Identifier* VarRef::identifier() const
 {
     return identifier_;
+}
+
+// ----------------------------------------------------------------------------
+Type VarRef::getType() const
+{
+    return variable_ ? variable_->type() : Type::getUnknown();
+}
+
+// ----------------------------------------------------------------------------
+void VarRef::setVariable(Variable* variable)
+{
+    assert(identifier_->name() == variable->name());
+    variable_ = variable;
+}
+
+// ----------------------------------------------------------------------------
+Variable* VarRef::variable() const
+{
+    assert(identifier_->name() == variable_->name());
+    return variable_;
 }
 
 // ----------------------------------------------------------------------------

--- a/odb-compiler/src/ast/Variable.cpp
+++ b/odb-compiler/src/ast/Variable.cpp
@@ -1,72 +1,81 @@
-#include "odb-compiler/ast/Identifier.hpp"
-
 #include <utility>
+
+#include "odb-compiler/ast/Variable.hpp"
 #include "odb-compiler/ast/Visitor.hpp"
 
 namespace odb::ast {
 
 // ----------------------------------------------------------------------------
-Identifier::Identifier(std::string  name, SourceLocation* location) :
+Variable::Variable(SourceLocation* location, std::string name, Type type) :
     Node(location),
     name_(std::move(name)),
-    annotation_(Annotation::NONE)
+    annotation_(Annotation::NONE),
+    type_(std::move(type))
 {
 }
 
 // ----------------------------------------------------------------------------
-Identifier::Identifier(std::string name, Annotation annotation, SourceLocation* location) :
+Variable::Variable(SourceLocation* location, std::string name, Annotation annotation, Type type) :
     Node(location),
     name_(std::move(name)),
-    annotation_(annotation)
+    annotation_(annotation),
+    type_(std::move(type))
 {
 }
 
 // ----------------------------------------------------------------------------
-const std::string& Identifier::name() const
+const std::string& Variable::name() const
 {
     return name_;
 }
 
 // ----------------------------------------------------------------------------
-Annotation Identifier::annotation() const
+Annotation Variable::annotation() const
 {
     return annotation_;
 }
 
 // ----------------------------------------------------------------------------
-std::string Identifier::toString() const
+Type Variable::type() const
 {
-    return std::string("Identifier(")
+    return type_;
+}
+
+// ----------------------------------------------------------------------------
+std::string Variable::toString() const
+{
+    return std::string("Variable(")
            + typeAnnotationEnumString(annotation_)
            + "): \"" + name_ + "\"";
 }
 
 // ----------------------------------------------------------------------------
-void Identifier::accept(Visitor* visitor)
+void Variable::accept(Visitor* visitor)
 {
-    visitor->visitIdentifier(this);
+    visitor->visitVariable(this);
 }
-void Identifier::accept(ConstVisitor* visitor) const
+void Variable::accept(ConstVisitor* visitor) const
 {
-    visitor->visitIdentifier(this);
+    visitor->visitVariable(this);
 }
 
 // ----------------------------------------------------------------------------
-Node::ChildRange Identifier::children()
+Node::ChildRange Variable::children()
 {
     return {};
 }
 
 // ----------------------------------------------------------------------------
-void Identifier::swapChild(const Node* oldNode, Node* newNode)
+void Variable::swapChild(const Node* oldNode, Node* newNode)
 {
     assert(false);
 }
 
 // ----------------------------------------------------------------------------
-Node* Identifier::duplicateImpl() const
+Node* Variable::duplicateImpl() const
 {
-    return new Identifier(name_, annotation_, location());
+    assert(false);
+    return nullptr;
 }
 
 }

--- a/odb-compiler/src/ast/Visitor.cpp
+++ b/odb-compiler/src/ast/Visitor.cpp
@@ -29,6 +29,7 @@
 #include "odb-compiler/ast/UDTField.hpp"
 #include "odb-compiler/ast/UnaryOp.hpp"
 #include "odb-compiler/ast/VarDecl.hpp"
+#include "odb-compiler/ast/Variable.hpp"
 #include "odb-compiler/ast/VarRef.hpp"
 #include "odb-compiler/commands/Command.hpp"
 

--- a/odb-compiler/src/ast/Visitor.cpp
+++ b/odb-compiler/src/ast/Visitor.cpp
@@ -14,6 +14,7 @@
 #include "odb-compiler/ast/FuncDecl.hpp"
 #include "odb-compiler/ast/Goto.hpp"
 #include "odb-compiler/ast/Identifier.hpp"
+#include "odb-compiler/ast/ImplicitCast.hpp"
 #include "odb-compiler/ast/InitializerList.hpp"
 #include "odb-compiler/ast/Label.hpp"
 #include "odb-compiler/ast/Literal.hpp"

--- a/odb-compiler/src/ast/Visitor.cpp
+++ b/odb-compiler/src/ast/Visitor.cpp
@@ -34,101 +34,16 @@
 namespace odb::ast {
 
 // ----------------------------------------------------------------------------
-void GenericVisitor::visitArgList(ArgList* node)                               { visit(node); }
-void GenericVisitor::visitArrayAssignment(ArrayAssignment* node)               { visit(node); }
-void GenericVisitor::visitArrayDecl(ArrayDecl* node)                           { visit(node); }
-void GenericVisitor::visitArrayRef(ArrayRef* node)                             { visit(node); }
-void GenericVisitor::visitBinaryOp(BinaryOp* node)                             { visit(node); }
-void GenericVisitor::visitBlock(Block* node)                                   { visit(node); }
-void GenericVisitor::visitCase(Case* node)                                     { visit(node); }
-void GenericVisitor::visitCaseList(CaseList* node)                             { visit(node); }
-void GenericVisitor::visitCommandExpr(CommandExpr* node)                       { visit(node); }
-void GenericVisitor::visitCommandStmnt(CommandStmnt* node)                     { visit(node); }
-void GenericVisitor::visitConditional(Conditional* node)                       { visit(node); }
-void GenericVisitor::visitConstDecl(ConstDecl* node)                           { visit(node); }
-void GenericVisitor::visitConstDeclExpr(ConstDeclExpr* node)                   { visit(node); }
-void GenericVisitor::visitDefaultCase(DefaultCase* node)                       { visit(node); }
-void GenericVisitor::visitExit(Exit* node)                                     { visit(node); }
-void GenericVisitor::visitForLoop(ForLoop* node)                               { visit(node); }
-void GenericVisitor::visitFuncCallExpr(FuncCallExpr* node)                     { visit(node); }
-void GenericVisitor::visitFuncCallExprOrArrayRef(FuncCallExprOrArrayRef* node) { visit(node); }
-void GenericVisitor::visitFuncCallStmnt(FuncCallStmnt* node)                   { visit(node); }
-void GenericVisitor::visitFuncDecl(FuncDecl* node)                             { visit(node); }
-void GenericVisitor::visitFuncExit(FuncExit* node)                             { visit(node); }
-void GenericVisitor::visitGoto(Goto* node)                                     { visit(node); }
-void GenericVisitor::visitIdentifier(Identifier* node)                         { visit(node); }
-void GenericVisitor::visitInfiniteLoop(InfiniteLoop* node)                     { visit(node); }
-void GenericVisitor::visitInitializerList(InitializerList* node)               { visit(node); }
-void GenericVisitor::visitLabel(Label* node)                                   { visit(node); }
-void GenericVisitor::visitScopedIdentifier(ScopedIdentifier* node)             { visit(node); }
-void GenericVisitor::visitSelect(Select* node)                                 { visit(node); }
-void GenericVisitor::visitSubCall(SubCall* node)                               { visit(node); }
-void GenericVisitor::visitSubReturn(SubReturn* node)                           { visit(node); }
-void GenericVisitor::visitVarDecl(VarDecl* node)                               { visit(node); }
-void GenericVisitor::visitUDTDecl(UDTDecl* node)                               { visit(node); }
-void GenericVisitor::visitUDTDeclBody(UDTDeclBody* node)                       { visit(node); }
-void GenericVisitor::visitUDTFieldOuter(UDTFieldOuter* node)                   { visit(node); }
-void GenericVisitor::visitUDTFieldInner(UDTFieldInner* node)                   { visit(node); }
-void GenericVisitor::visitUDTFieldAssignment(UDTFieldAssignment* node)         { visit(node); }
-void GenericVisitor::visitUnaryOp(UnaryOp* node)                               { visit(node); }
-void GenericVisitor::visitUntilLoop(UntilLoop* node)                           { visit(node); }
-void GenericVisitor::visitVarAssignment(VarAssignment* node)                   { visit(node); }
-void GenericVisitor::visitVarRef(VarRef* node)                                 { visit(node); }
-void GenericVisitor::visitWhileLoop(WhileLoop* node)                           { visit(node); }
-
-#define X(dbname, cppname) \
-    void GenericVisitor::visit##dbname##Literal(dbname##Literal* node)         { visit(node); }
-ODB_DATATYPE_LIST
+#define X(nodeType) void GenericVisitor::visit##nodeType(nodeType* node) { visit(node); }
+ODB_AST_NODE_TYPE_LIST
 #undef X
 
 // ----------------------------------------------------------------------------
-void GenericConstVisitor::visitArgList(const ArgList* node)                               { visit(node); }
-void GenericConstVisitor::visitArrayAssignment(const ArrayAssignment* node)               { visit(node); }
-void GenericConstVisitor::visitArrayDecl(const ArrayDecl* node)                           { visit(node); }
-void GenericConstVisitor::visitArrayRef(const ArrayRef* node)                             { visit(node); }
-void GenericConstVisitor::visitBinaryOp(const BinaryOp* node)                             { visit(node); }
-void GenericConstVisitor::visitBlock(const Block* node)                                   { visit(node); }
-void GenericConstVisitor::visitCase(const Case* node)                                     { visit(node); }
-void GenericConstVisitor::visitCaseList(const CaseList* node)                             { visit(node); }
-void GenericConstVisitor::visitCommandExpr(const CommandExpr* node)                       { visit(node); }
-void GenericConstVisitor::visitCommandStmnt(const CommandStmnt* node)                     { visit(node); }
-void GenericConstVisitor::visitConditional(const Conditional* node)                       { visit(node); }
-void GenericConstVisitor::visitConstDecl(const ConstDecl* node)                           { visit(node); }
-void GenericConstVisitor::visitConstDeclExpr(const ConstDeclExpr* node)                   { visit(node); }
-void GenericConstVisitor::visitDefaultCase(const DefaultCase* node)                       { visit(node); }
-void GenericConstVisitor::visitExit(const Exit* node)                                     { visit(node); }
-void GenericConstVisitor::visitForLoop(const ForLoop* node)                               { visit(node); }
-void GenericConstVisitor::visitFuncCallExpr(const FuncCallExpr* node)                     { visit(node); }
-void GenericConstVisitor::visitFuncCallExprOrArrayRef(const FuncCallExprOrArrayRef* node) { visit(node); }
-void GenericConstVisitor::visitFuncCallStmnt(const FuncCallStmnt* node)                   { visit(node); }
-void GenericConstVisitor::visitFuncDecl(const FuncDecl* node)                             { visit(node); }
-void GenericConstVisitor::visitFuncExit(const FuncExit* node)                             { visit(node); }
-void GenericConstVisitor::visitGoto(const Goto* node)                                     { visit(node); }
-void GenericConstVisitor::visitIdentifier(const Identifier* node)                         { visit(node); }
-void GenericConstVisitor::visitInfiniteLoop(const InfiniteLoop* node)                     { visit(node); }
-void GenericConstVisitor::visitInitializerList(const InitializerList* node)               { visit(node); }
-void GenericConstVisitor::visitLabel(const Label* node)                                   { visit(node); }
-void GenericConstVisitor::visitScopedIdentifier(const ScopedIdentifier* node)             { visit(node); }
-void GenericConstVisitor::visitSelect(const Select* node)                                 { visit(node); }
-void GenericConstVisitor::visitSubCall(const SubCall* node)                               { visit(node); }
-void GenericConstVisitor::visitSubReturn(const SubReturn* node)                           { visit(node); }
-void GenericConstVisitor::visitVarDecl(const VarDecl* node)                               { visit(node); }
-void GenericConstVisitor::visitUDTDecl(const UDTDecl* node)                               { visit(node); }
-void GenericConstVisitor::visitUDTDeclBody(const UDTDeclBody* node)                       { visit(node); }
-void GenericConstVisitor::visitUDTFieldOuter(const UDTFieldOuter* node)                   { visit(node); }
-void GenericConstVisitor::visitUDTFieldInner(const UDTFieldInner* node)                   { visit(node); }
-void GenericConstVisitor::visitUDTFieldAssignment(const UDTFieldAssignment* node)         { visit(node); }
-void GenericConstVisitor::visitUnaryOp(const UnaryOp* node)                               { visit(node); }
-void GenericConstVisitor::visitUntilLoop(const UntilLoop* node)                           { visit(node); }
-void GenericConstVisitor::visitVarAssignment(const VarAssignment* node)                   { visit(node); }
-void GenericConstVisitor::visitVarRef(const VarRef* node)                                 { visit(node); }
-void GenericConstVisitor::visitWhileLoop(const WhileLoop* node)                           { visit(node); }
-
-#define X(dbname, cppname) \
-    void GenericConstVisitor::visit##dbname##Literal(const dbname##Literal* node)         { visit(node); }
-ODB_DATATYPE_LIST
+#define X(nodeType) void GenericConstVisitor::visit##nodeType(const nodeType* node) { visit(node); }
+ODB_AST_NODE_TYPE_LIST
 #undef X
 
+// ----------------------------------------------------------------------------
 void visitAST(Node* node, Visitor& visitor, Traversal traversal)
 {
     switch (traversal)
@@ -150,6 +65,7 @@ void visitAST(Node* node, Visitor& visitor, Traversal traversal)
     }
 }
 
+// ----------------------------------------------------------------------------
 void visitAST(const Node* node, ConstVisitor& visitor, Traversal traversal)
 {
     switch (traversal)

--- a/odb-compiler/src/ast/Visitor.cpp
+++ b/odb-compiler/src/ast/Visitor.cpp
@@ -19,6 +19,7 @@
 #include "odb-compiler/ast/Literal.hpp"
 #include "odb-compiler/ast/Loop.hpp"
 #include "odb-compiler/ast/Node.hpp"
+#include "odb-compiler/ast/Program.hpp"
 #include "odb-compiler/ast/ScopedIdentifier.hpp"
 #include "odb-compiler/ast/SelectCase.hpp"
 #include "odb-compiler/ast/SourceLocation.hpp"

--- a/odb-compiler/src/astpost/ValidateUDTFieldNames.cpp
+++ b/odb-compiler/src/astpost/ValidateUDTFieldNames.cpp
@@ -73,7 +73,7 @@ bool Visitor::check(const ast::CommandExpr* cmd)
     if (cmd == nullptr)
         return false;
 
-    char c = cmd->command().back();
+    char c = cmd->commandName().back();
     if (ast::isAnnotation(c))
     {
         Log::dbParserSemanticError(
@@ -90,7 +90,7 @@ bool Visitor::check(const ast::CommandStmnt* cmd)
     if (cmd == nullptr)
         return false;
 
-    char c = cmd->command().back();
+    char c = cmd->commandName().back();
     if (ast::isAnnotation(c))
     {
         Log::dbParserSemanticError(

--- a/odb-compiler/src/ir/semantic/ASTConverter.cpp
+++ b/odb-compiler/src/ir/semantic/ASTConverter.cpp
@@ -364,7 +364,7 @@ Ptr<Expression> ASTConverter::convertExpression(const ast::Expression* expressio
     {
         // TODO: Perform type checking of arguments.
         return std::make_unique<FunctionCallExpression>(
-            convertCommandCallExpression(location, command->command(), command->args()));
+            convertCommandCallExpression(location, command->commandName(), command->args()));
     }
     else if (auto* funcCall = dynamic_cast<const ast::FuncCallExpr*>(expression))
     {
@@ -544,7 +544,7 @@ Ptr<Statement> ASTConverter::convertStatement(ast::Statement* statement, Loop* c
     {
         return std::make_unique<FunctionCall>(
             location, currentFunction_,
-            convertCommandCallExpression(commandSt->location(), commandSt->command(), commandSt->args()));
+            convertCommandCallExpression(commandSt->location(), commandSt->commandName(), commandSt->args()));
     }
     else
     {

--- a/odb-compiler/src/parsers/db/Driver.cpp
+++ b/odb-compiler/src/parsers/db/Driver.cpp
@@ -45,7 +45,7 @@ static bool tokenHasFreeableString(int pushedChar)
 }
 
 // ----------------------------------------------------------------------------
-ast::Block* Driver::doParse(dbscan_t scanner, dbpstate* parser, const cmd::CommandMatcher& commandMatcher)
+ast::Program* Driver::doParse(dbscan_t scanner, dbpstate* parser, const cmd::CommandMatcher& commandMatcher)
 {
     int parseResult;
     DBLTYPE loc = {1, 1, 1, 1};
@@ -278,7 +278,7 @@ ast::Block* Driver::doParse(dbscan_t scanner, dbpstate* parser, const cmd::Comma
 
     if (parseResult == 0)
     {
-        ast::Block* program = program_;
+        ast::Program* program = program_;
         program_.detach();
         return program;
     }
@@ -287,7 +287,7 @@ ast::Block* Driver::doParse(dbscan_t scanner, dbpstate* parser, const cmd::Comma
 }
 
 // ----------------------------------------------------------------------------
-void Driver::giveProgram(ast::Block* program)
+void Driver::giveProgram(ast::Program* program)
 {
     if (program_.notNull())
     {
@@ -390,7 +390,7 @@ ast::Assignment* Driver::newIncDecUDTField(ast::UDTFieldOuter* value, IncDecDir 
 }
 
 // ----------------------------------------------------------------------------
-ast::Block* FileParserDriver::parse(const std::string& fileName,
+ast::Program* FileParserDriver::parse(const std::string& fileName,
                                     const cmd::CommandMatcher& commandMatcher)
 {
     FILE* fp = fopen(fileName.c_str(), "r");
@@ -408,7 +408,7 @@ ast::Block* FileParserDriver::parse(const std::string& fileName,
     dbset_in(fp, scanner);
 
     fileName_ = &fileName;
-    ast::Block* program = doParse(scanner, parser, commandMatcher);
+    ast::Program* program = doParse(scanner, parser, commandMatcher);
     fileName_ = nullptr;
 
     // Destroy parser and lexer
@@ -420,7 +420,7 @@ ast::Block* FileParserDriver::parse(const std::string& fileName,
 }
 
 // ----------------------------------------------------------------------------
-ast::Block* StringParserDriver::parse(const std::string& sourceName,
+ast::Program* StringParserDriver::parse(const std::string& sourceName,
                                       const std::string& str,
                                       const cmd::CommandMatcher& commandMatcher)
 {
@@ -433,7 +433,7 @@ ast::Block* StringParserDriver::parse(const std::string& sourceName,
 
     code_ = &str;
     sourceName_ = &sourceName;
-    ast::Block* program = doParse(scanner, parser, commandMatcher);
+    ast::Program* program = doParse(scanner, parser, commandMatcher);
     sourceName_ = nullptr;
     code_ = nullptr;
 

--- a/odb-compiler/src/parsers/db/Parser.y
+++ b/odb-compiler/src/parsers/db/Parser.y
@@ -22,6 +22,7 @@
     #include "odb-compiler/ast/Literal.hpp"
     #include "odb-compiler/ast/Loop.hpp"
     #include "odb-compiler/ast/LValue.hpp"
+    #include "odb-compiler/ast/Program.hpp"
     #include "odb-compiler/ast/ScopedIdentifier.hpp"
     #include "odb-compiler/ast/SelectCase.hpp"
     #include "odb-compiler/ast/SourceLocation.hpp"
@@ -433,7 +434,7 @@
 
 %%
 program
-  : seps_maybe block seps_maybe                               { $$ = $2; driver->giveProgram($2); }
+  : seps_maybe block seps_maybe                               { $$ = $2; driver->giveProgram(new Program($2, $2->location())); }
   | seps_maybe                                                { $$ = nullptr; }
   ;
 sep : '\n' | ':' | ';' ;

--- a/odb-compiler/tests/include/odb-compiler/tests/ASTMockVisitor.hpp
+++ b/odb-compiler/tests/include/odb-compiler/tests/ASTMockVisitor.hpp
@@ -6,51 +6,7 @@
 class ASTMockVisitor : public odb::ast::ConstVisitor
 {
 public:
-    MOCK_METHOD(void, visitArgList, (const odb::ast::ArgList* node), (override));
-    MOCK_METHOD(void, visitArrayAssignment, (const odb::ast::ArrayAssignment* node), (override));
-    MOCK_METHOD(void, visitArrayDecl, (const odb::ast::ArrayDecl* node), (override));
-    MOCK_METHOD(void, visitArrayRef, (const odb::ast::ArrayRef* node), (override));
-    MOCK_METHOD(void, visitBinaryOp, (const odb::ast::BinaryOp* node), (override));
-    MOCK_METHOD(void, visitBlock, (const odb::ast::Block* node), (override));
-    MOCK_METHOD(void, visitCase, (const odb::ast::Case* node), (override));
-    MOCK_METHOD(void, visitCaseList, (const odb::ast::CaseList* node), (override));
-    MOCK_METHOD(void, visitCommandExpr, (const odb::ast::CommandExpr* node), (override));
-    MOCK_METHOD(void, visitCommandStmnt, (const odb::ast::CommandStmnt* node), (override));
-    MOCK_METHOD(void, visitConditional, (const odb::ast::Conditional* node), (override));
-    MOCK_METHOD(void, visitConstDecl, (const odb::ast::ConstDecl* node), (override));
-    MOCK_METHOD(void, visitConstDeclExpr, (const odb::ast::ConstDeclExpr* node), (override));
-    MOCK_METHOD(void, visitDefaultCase, (const odb::ast::DefaultCase* node), (override));
-    MOCK_METHOD(void, visitExit, (const odb::ast::Exit* node), (override));
-    MOCK_METHOD(void, visitForLoop, (const odb::ast::ForLoop* node), (override));
-    MOCK_METHOD(void, visitFuncCallExprOrArrayRef, (const odb::ast::FuncCallExprOrArrayRef* node), (override));
-    MOCK_METHOD(void, visitFuncCallExpr, (const odb::ast::FuncCallExpr* node), (override));
-    MOCK_METHOD(void, visitFuncCallStmnt, (const odb::ast::FuncCallStmnt* node), (override));
-    MOCK_METHOD(void, visitFuncDecl, (const odb::ast::FuncDecl* node), (override));
-    MOCK_METHOD(void, visitFuncExit, (const odb::ast::FuncExit* node), (override));
-    MOCK_METHOD(void, visitGoto, (const odb::ast::Goto* node), (override));
-    MOCK_METHOD(void, visitIdentifier, (const odb::ast::Identifier* node), (override));
-    MOCK_METHOD(void, visitInfiniteLoop, (const odb::ast::InfiniteLoop* node), (override));
-    MOCK_METHOD(void, visitInitializerList, (const odb::ast::InitializerList* node), (override));
-    MOCK_METHOD(void, visitLabel, (const odb::ast::Label* node), (override));
-    MOCK_METHOD(void, visitScopedIdentifier, (const odb::ast::ScopedIdentifier* node), (override));
-    MOCK_METHOD(void, visitSelect, (const odb::ast::Select* node), (override));
-    MOCK_METHOD(void, visitSubCall, (const odb::ast::SubCall* node), (override));
-    MOCK_METHOD(void, visitSubReturn, (const odb::ast::SubReturn* node), (override));
-    MOCK_METHOD(void, visitVarDecl, (const odb::ast::VarDecl* node), (override));
-    MOCK_METHOD(void, visitUDTDecl, (const odb::ast::UDTDecl* node), (override));
-    MOCK_METHOD(void, visitUDTDeclBody, (const odb::ast::UDTDeclBody* node), (override));
-    MOCK_METHOD(void, visitUDTFieldAssignment, (const odb::ast::UDTFieldAssignment* node), (override));
-    MOCK_METHOD(void, visitUDTFieldOuter, (const odb::ast::UDTFieldOuter* node), (override));
-    MOCK_METHOD(void, visitUDTFieldInner, (const odb::ast::UDTFieldInner* node), (override));
-    MOCK_METHOD(void, visitUnaryOp, (const odb::ast::UnaryOp* node), (override));
-    MOCK_METHOD(void, visitUntilLoop, (const odb::ast::UntilLoop* node), (override));
-    MOCK_METHOD(void, visitVarAssignment, (const odb::ast::VarAssignment* node), (override));
-    MOCK_METHOD(void, visitVarRef, (const odb::ast::VarRef* node), (override));
-    MOCK_METHOD(void, visitWhileLoop, (const odb::ast::WhileLoop* node), (override));
-
-#define X(dbname, cppname) \
-    MOCK_METHOD(void, visit##dbname##Literal, (const odb::ast::dbname##Literal* node), (override));
-    ODB_DATATYPE_LIST
+#define X(nodeType) MOCK_METHOD(void, visit##nodeType, (const odb::ast::nodeType* node), (override));
+    ODB_AST_NODE_TYPE_LIST
 #undef X
-
 };

--- a/odb-compiler/tests/include/odb-compiler/tests/ParserTestHarness.hpp
+++ b/odb-compiler/tests/include/odb-compiler/tests/ParserTestHarness.hpp
@@ -2,12 +2,10 @@
 
 #include "odb-compiler/commands/CommandMatcher.hpp"
 #include "odb-compiler/commands/CommandIndex.hpp"
+#include "odb-compiler/ast/Program.hpp"
 #include "odb-sdk/Reference.hpp"
 #include "gmock/gmock.h"
 
-namespace odb::ast {
-    class Block;
-}
 namespace odb::db {
     class FileParserDriver;
 }
@@ -23,5 +21,5 @@ public:
     odb::cmd::CommandIndex cmdIndex;
     odb::cmd::CommandMatcher matcher;
     odb::db::StringParserDriver* driver;
-    odb::Reference<odb::ast::Block> ast;
+    odb::Reference<odb::ast::Program> ast;
 };

--- a/odb-compiler/tests/include/odb-compiler/tests/matchers/CommandExprEq.hpp
+++ b/odb-compiler/tests/include/odb-compiler/tests/matchers/CommandExprEq.hpp
@@ -9,15 +9,15 @@ namespace odb::ast {
 class CommandExprEqMatcher : public testing::MatcherInterface<const odb::ast::CommandExpr*>
 {
 public:
-    explicit CommandExprEqMatcher(const std::string& name);
+    explicit CommandExprEqMatcher(std::string name);
     bool MatchAndExplain(const odb::ast::CommandExpr* node, testing::MatchResultListener* listener) const override;
     void DescribeTo(::std::ostream* os) const override;
     void DescribeNegationTo(::std::ostream* os) const override;
 
 private:
-    const std::string expectedCommand_;
+    const std::string expectedCommandName_;
 };
 
-inline testing::Matcher<const odb::ast::CommandExpr*> CommandExprEq(const std::string& name) {
-    return MakeMatcher(new CommandExprEqMatcher(name));
+inline testing::Matcher<const odb::ast::CommandExpr*> CommandExprEq(std::string name) {
+    return MakeMatcher(new CommandExprEqMatcher(std::move(name)));
 }

--- a/odb-compiler/tests/include/odb-compiler/tests/matchers/CommandStmntEq.hpp
+++ b/odb-compiler/tests/include/odb-compiler/tests/matchers/CommandStmntEq.hpp
@@ -9,15 +9,15 @@ namespace odb::ast {
 class CommandStmntEqMatcher : public testing::MatcherInterface<const odb::ast::CommandStmnt*>
 {
 public:
-    explicit CommandStmntEqMatcher(const std::string& name);
+    explicit CommandStmntEqMatcher(std::string name);
     bool MatchAndExplain(const odb::ast::CommandStmnt* node, testing::MatchResultListener* listener) const override;
     void DescribeTo(::std::ostream* os) const override;
     void DescribeNegationTo(::std::ostream* os) const override;
 
 private:
-    const std::string expectedCommand_;
+    const std::string expectedCommandName_;
 };
 
-inline testing::Matcher<const odb::ast::CommandStmnt*> CommandStmntEq(const std::string& name) {
-    return testing::MakeMatcher(new CommandStmntEqMatcher(name));
+inline testing::Matcher<const odb::ast::CommandStmnt*> CommandStmntEq(std::string name) {
+    return testing::MakeMatcher(new CommandStmntEqMatcher(std::move(name)));
 }

--- a/odb-compiler/tests/src/ast/test_ast_treeiterator.cpp
+++ b/odb-compiler/tests/src/ast/test_ast_treeiterator.cpp
@@ -83,24 +83,28 @@ TEST_F(ASTPreOrderIteratorTest, TraversalWithParents)
     auto range = preOrderTraversal(ast);
     auto it = range.begin();
 
-    ASSERT_NE(dynamic_cast<Block*>(*it), nullptr);
+    ASSERT_NE(dynamic_cast<Program*>(*it), nullptr);
     EXPECT_EQ(it.parent(), nullptr);
     it++;
 
-    ASSERT_NE(dynamic_cast<VarAssignment*>(*it), nullptr);
+    ASSERT_NE(dynamic_cast<Block*>(*it), nullptr);
     EXPECT_EQ(it.parent(), ast);
     it++;
 
+    ASSERT_NE(dynamic_cast<VarAssignment*>(*it), nullptr);
+    EXPECT_EQ(it.parent(), ast->body());
+    it++;
+
     ASSERT_NE(dynamic_cast<VarRef*>(*it), nullptr);
-    EXPECT_EQ(it.parent(), ast->statements()[0]);
+    EXPECT_EQ(it.parent(), ast->body()->statements()[0]);
     it++;
 
     ASSERT_NE(dynamic_cast<Identifier*>(*it), nullptr);
-    EXPECT_EQ(it.parent(), ast->statements()[0]->children()[0]);
+    EXPECT_EQ(it.parent(), ast->body()->statements()[0]->children()[0]);
     it++;
 
     ASSERT_NE(dynamic_cast<ByteLiteral*>(*it), nullptr);
-    EXPECT_EQ(it.parent(), ast->statements()[0]);
+    EXPECT_EQ(it.parent(), ast->body()->statements()[0]);
     it++;
 
     ASSERT_EQ(it, range.end());
@@ -112,16 +116,20 @@ TEST_F(ASTPreOrderIteratorTest, ReplaceNodeWhilstIterating)
     auto range = preOrderTraversal(ast);
     auto it = range.begin();
 
-    ASSERT_NE(dynamic_cast<Block*>(*it), nullptr);
+    ASSERT_NE(dynamic_cast<Program*>(*it), nullptr);
     EXPECT_EQ(it.parent(), nullptr);
     it++;
 
-    ASSERT_NE(dynamic_cast<VarAssignment*>(*it), nullptr);
+    ASSERT_NE(dynamic_cast<Block*>(*it), nullptr);
     EXPECT_EQ(it.parent(), ast);
     it++;
 
+    ASSERT_NE(dynamic_cast<VarAssignment*>(*it), nullptr);
+    EXPECT_EQ(it.parent(), ast->body());
+    it++;
+
     ASSERT_NE(dynamic_cast<VarRef*>(*it), nullptr);
-    EXPECT_EQ(it.parent(), ast->statements()[0]);
+    EXPECT_EQ(it.parent(), ast->body()->statements()[0]);
 
     // Replace the VarRef with a different VarRef. That way, we can be sure we traverse into the _new_ children.
     Node* previousNode = *it;
@@ -129,18 +137,18 @@ TEST_F(ASTPreOrderIteratorTest, ReplaceNodeWhilstIterating)
                               (*it)->location()));
     ASSERT_NE(dynamic_cast<VarRef*>(*it), nullptr);
     EXPECT_NE(*it, previousNode);
-    EXPECT_EQ(it.parent(), ast->statements()[0]);
+    EXPECT_EQ(it.parent(), ast->body()->statements()[0]);
     it++;
 
     ASSERT_NE(dynamic_cast<Identifier*>(*it), nullptr);
-    EXPECT_EQ(it.parent(), ast->statements()[0]->children()[0]);
+    EXPECT_EQ(it.parent(), ast->body()->statements()[0]->children()[0]);
     // Ensure we traversed over the new child of the replacement VarRef.
     EXPECT_EQ(dynamic_cast<Identifier*>(*it)->name(), "someFloat");
     EXPECT_EQ(dynamic_cast<Identifier*>(*it)->annotation(), Annotation::FLOAT);
     it++;
 
     ASSERT_NE(dynamic_cast<ByteLiteral*>(*it), nullptr);
-    EXPECT_EQ(it.parent(), ast->statements()[0]);
+    EXPECT_EQ(it.parent(), ast->body()->statements()[0]);
     it++;
 
     ASSERT_EQ(it, range.end());
@@ -152,16 +160,20 @@ TEST_F(ASTPreOrderIteratorTest, ModifyChildrenWhilstIterating)
     auto range = preOrderTraversal(ast);
     auto it = range.begin();
 
-    ASSERT_NE(dynamic_cast<Block*>(*it), nullptr);
+    ASSERT_NE(dynamic_cast<Program*>(*it), nullptr);
     EXPECT_EQ(it.parent(), nullptr);
     it++;
 
-    ASSERT_NE(dynamic_cast<VarAssignment*>(*it), nullptr);
+    ASSERT_NE(dynamic_cast<Block*>(*it), nullptr);
     EXPECT_EQ(it.parent(), ast);
     it++;
 
+    ASSERT_NE(dynamic_cast<VarAssignment*>(*it), nullptr);
+    EXPECT_EQ(it.parent(), ast->body());
+    it++;
+
     ASSERT_NE(dynamic_cast<VarRef*>(*it), nullptr);
-    EXPECT_EQ(it.parent(), ast->statements()[0]);
+    EXPECT_EQ(it.parent(), ast->body()->statements()[0]);
 
     // Perform the same modification as in the previous test, but instead modify the child of VarRef directly (which may
     // affect iteration).
@@ -171,14 +183,14 @@ TEST_F(ASTPreOrderIteratorTest, ModifyChildrenWhilstIterating)
     it++;
 
     ASSERT_NE(dynamic_cast<Identifier*>(*it), nullptr);
-    EXPECT_EQ(it.parent(), ast->statements()[0]->children()[0]);
+    EXPECT_EQ(it.parent(), ast->body()->statements()[0]->children()[0]);
     // Ensure we traversed over the replacement child of the VarRef.
     EXPECT_EQ(dynamic_cast<Identifier*>(*it)->name(), "someFloat");
     EXPECT_EQ(dynamic_cast<Identifier*>(*it)->annotation(), Annotation::FLOAT);
     it++;
 
     ASSERT_NE(dynamic_cast<ByteLiteral*>(*it), nullptr);
-    EXPECT_EQ(it.parent(), ast->statements()[0]);
+    EXPECT_EQ(it.parent(), ast->body()->statements()[0]);
     it++;
 
     ASSERT_EQ(it, range.end());
@@ -236,22 +248,26 @@ TEST_F(ASTPostOrderIteratorTest, TraversalWithParents)
     auto it = range.begin();
 
     ASSERT_NE(dynamic_cast<Identifier*>(*it), nullptr);
-    EXPECT_EQ(it.parent(), ast->statements()[0]->children()[0]);
+    EXPECT_EQ(it.parent(), ast->body()->statements()[0]->children()[0]);
     it++;
 
     ASSERT_NE(dynamic_cast<VarRef*>(*it), nullptr);
-    EXPECT_EQ(it.parent(), ast->statements()[0]);
+    EXPECT_EQ(it.parent(), ast->body()->statements()[0]);
     it++;
 
     ASSERT_NE(dynamic_cast<ByteLiteral*>(*it), nullptr);
-    EXPECT_EQ(it.parent(), ast->statements()[0]);
+    EXPECT_EQ(it.parent(), ast->body()->statements()[0]);
     it++;
 
     ASSERT_NE(dynamic_cast<VarAssignment*>(*it), nullptr);
-    EXPECT_EQ(it.parent(), ast);
+    EXPECT_EQ(it.parent(), ast->body());
     it++;
 
     ASSERT_NE(dynamic_cast<Block*>(*it), nullptr);
+    EXPECT_EQ(it.parent(), ast);
+    it++;
+
+    ASSERT_NE(dynamic_cast<Program*>(*it), nullptr);
     EXPECT_EQ(it.parent(), nullptr);
     it++;
 
@@ -265,11 +281,11 @@ TEST_F(ASTPostOrderIteratorTest, ReplaceNodeWhilstIterating)
     auto it = range.begin();
 
     ASSERT_NE(dynamic_cast<Identifier*>(*it), nullptr);
-    EXPECT_EQ(it.parent(), ast->statements()[0]->children()[0]);
+    EXPECT_EQ(it.parent(), ast->body()->statements()[0]->children()[0]);
     it++;
 
     ASSERT_NE(dynamic_cast<VarRef*>(*it), nullptr);
-    EXPECT_EQ(it.parent(), ast->statements()[0]);
+    EXPECT_EQ(it.parent(), ast->body()->statements()[0]);
 
     // Replace the VarRef with a different VarRef. At this point, we've already traversed into the children, so this
     // shouldn't change anything except what the iterator points to.
@@ -278,18 +294,22 @@ TEST_F(ASTPostOrderIteratorTest, ReplaceNodeWhilstIterating)
                               (*it)->location()));
     ASSERT_NE(dynamic_cast<VarRef*>(*it), nullptr);
     EXPECT_NE(*it, previousNode);
-    EXPECT_EQ(it.parent(), ast->statements()[0]);
+    EXPECT_EQ(it.parent(), ast->body()->statements()[0]);
     it++;
 
     ASSERT_NE(dynamic_cast<ByteLiteral*>(*it), nullptr);
-    EXPECT_EQ(it.parent(), ast->statements()[0]);
+    EXPECT_EQ(it.parent(), ast->body()->statements()[0]);
     it++;
 
     ASSERT_NE(dynamic_cast<VarAssignment*>(*it), nullptr);
-    EXPECT_EQ(it.parent(), ast);
+    EXPECT_EQ(it.parent(), ast->body());
     it++;
 
     ASSERT_NE(dynamic_cast<Block*>(*it), nullptr);
+    EXPECT_EQ(it.parent(), ast);
+    it++;
+
+    ASSERT_NE(dynamic_cast<Program*>(*it), nullptr);
     EXPECT_EQ(it.parent(), nullptr);
     it++;
 
@@ -303,11 +323,11 @@ TEST_F(ASTPostOrderIteratorTest, ModifyChildrenWhilstIterating)
     auto it = range.begin();
 
     ASSERT_NE(dynamic_cast<Identifier*>(*it), nullptr);
-    EXPECT_EQ(it.parent(), ast->statements()[0]->children()[0]);
+    EXPECT_EQ(it.parent(), ast->body()->statements()[0]->children()[0]);
     it++;
 
     ASSERT_NE(dynamic_cast<VarRef*>(*it), nullptr);
-    EXPECT_EQ(it.parent(), ast->statements()[0]);
+    EXPECT_EQ(it.parent(), ast->body()->statements()[0]);
 
     // Perform the same modification as in the previous test, but instead modify the child of VarRef directly. This
     // should not affect iteration.
@@ -317,14 +337,18 @@ TEST_F(ASTPostOrderIteratorTest, ModifyChildrenWhilstIterating)
     it++;
 
     ASSERT_NE(dynamic_cast<ByteLiteral*>(*it), nullptr);
-    EXPECT_EQ(it.parent(), ast->statements()[0]);
+    EXPECT_EQ(it.parent(), ast->body()->statements()[0]);
     it++;
 
     ASSERT_NE(dynamic_cast<VarAssignment*>(*it), nullptr);
-    EXPECT_EQ(it.parent(), ast);
+    EXPECT_EQ(it.parent(), ast->body());
     it++;
 
     ASSERT_NE(dynamic_cast<Block*>(*it), nullptr);
+    EXPECT_EQ(it.parent(), ast);
+    it++;
+
+    ASSERT_NE(dynamic_cast<Program*>(*it), nullptr);
     EXPECT_EQ(it.parent(), nullptr);
     it++;
 

--- a/odb-compiler/tests/src/astpost/test_astpost_eliminate_bitwise_not_rhs.cpp
+++ b/odb-compiler/tests/src/astpost/test_astpost_eliminate_bitwise_not_rhs.cpp
@@ -61,7 +61,8 @@ TEST_F(NAME, no_side_effects_1)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("result", Annotation::NONE))).After(exp);
@@ -75,7 +76,8 @@ TEST_F(NAME, no_side_effects_1)
     post.addProcess(std::make_unique<astpost::EliminateBitwiseNotRHS>());
     ASSERT_THAT(post.execute(ast), IsTrue());
 
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("result", Annotation::NONE))).After(exp);
@@ -94,7 +96,8 @@ TEST_F(NAME, no_side_effects_2)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("result", Annotation::NONE))).After(exp);
@@ -109,7 +112,8 @@ TEST_F(NAME, no_side_effects_2)
     post.addProcess(std::make_unique<astpost::EliminateBitwiseNotRHS>());
     ASSERT_THAT(post.execute(ast), IsTrue());
 
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("result", Annotation::NONE))).After(exp);
@@ -128,7 +132,8 @@ TEST_F(NAME, no_side_effects_3)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("result", Annotation::NONE))).After(exp);
@@ -143,7 +148,8 @@ TEST_F(NAME, no_side_effects_3)
     post.addProcess(std::make_unique<astpost::EliminateBitwiseNotRHS>());
     ASSERT_THAT(post.execute(ast), IsTrue());
 
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("result", Annotation::NONE))).After(exp);

--- a/odb-compiler/tests/src/harness/ParserTestHarness.cpp
+++ b/odb-compiler/tests/src/harness/ParserTestHarness.cpp
@@ -1,4 +1,4 @@
-#include "odb-compiler/ast/Block.hpp"
+#include "odb-compiler/ast/Program.hpp"
 #include "odb-compiler/ast/Exporters.hpp"
 #include "odb-compiler/parsers/db/Driver.hpp"
 #include "odb-compiler/tests/ParserTestHarness.hpp"

--- a/odb-compiler/tests/src/matchers/CommandExprEq.cpp
+++ b/odb-compiler/tests/src/matchers/CommandExprEq.cpp
@@ -1,22 +1,22 @@
 #include "odb-compiler/tests/matchers/CommandExprEq.hpp"
 #include "odb-compiler/ast/CommandExpr.hpp"
 
-CommandExprEqMatcher::CommandExprEqMatcher(const std::string& name)
-    : expectedCommand_(name)
+CommandExprEqMatcher::CommandExprEqMatcher(std::string name)
+    : expectedCommandName_(std::move(name))
 {}
 
 bool CommandExprEqMatcher::MatchAndExplain(const odb::ast::CommandExpr* node, testing::MatchResultListener* listener) const
 {
-    *listener << "node->command() == " << node->command();
-    return node->command() == expectedCommand_;
+    *listener << "node->commandName() == " << node->commandName();
+    return node->commandName() == expectedCommandName_;
 }
 
 void CommandExprEqMatcher::DescribeTo(::std::ostream* os) const
 {
-    *os << "node->command() equals " << expectedCommand_;
+    *os << "node->command() equals " << expectedCommandName_;
 }
 
 void CommandExprEqMatcher::DescribeNegationTo(::std::ostream* os) const
 {
-    *os << "node->command() does not equal " << expectedCommand_;
+    *os << "node->command() does not equal " << expectedCommandName_;
 }

--- a/odb-compiler/tests/src/matchers/CommandStmntEq.cpp
+++ b/odb-compiler/tests/src/matchers/CommandStmntEq.cpp
@@ -1,22 +1,22 @@
 #include "odb-compiler/tests/matchers/CommandStmntEq.hpp"
 #include "odb-compiler/ast/CommandStmnt.hpp"
 
-CommandStmntEqMatcher::CommandStmntEqMatcher(const std::string& name)
-    : expectedCommand_(name)
+CommandStmntEqMatcher::CommandStmntEqMatcher(std::string name)
+    : expectedCommandName_(std::move(name))
 {}
 
 bool CommandStmntEqMatcher::MatchAndExplain(const odb::ast::CommandStmnt* node, testing::MatchResultListener* listener) const
 {
-    *listener << "node->command() == " << node->command();
-    return node->command() == expectedCommand_;
+    *listener << "node->commandName() == " << node->commandName();
+    return node->commandName() == expectedCommandName_;
 }
 
 void CommandStmntEqMatcher::DescribeTo(::std::ostream* os) const
 {
-    *os << "node->command() equals " << expectedCommand_;
+    *os << "node->command() equals " << expectedCommandName_;
 }
 
 void CommandStmntEqMatcher::DescribeNegationTo(::std::ostream* os) const
 {
-    *os << "node->command() does not equal " << expectedCommand_;
+    *os << "node->command() does not equal " << expectedCommandName_;
 }

--- a/odb-compiler/tests/src/parser/test_db_parser_array_decl.cpp
+++ b/odb-compiler/tests/src/parser/test_db_parser_array_decl.cpp
@@ -109,7 +109,8 @@ TEST_F(NAME, scope##_dim_arr_##ann##_defaults_to_##type)                      \
                                                                               \
     StrictMock<ASTMockVisitor> v;                                             \
     Expectation exp;                                                          \
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));                   \
+    exp = EXPECT_CALL(v, visitProgram(_));                                    \
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);        \
     exp = EXPECT_CALL(v, visitArrayDecl(ArrayDeclEq(BuiltinType::type##_type))).After(exp);\
     exp = EXPECT_CALL(v, visitScopedIdentifier(                               \
         ScopedIdentifierEq(scope##_scope, "arr", ann##_ann))).After(exp);     \
@@ -183,7 +184,8 @@ TEST_F(NAME, scope##_dim_arr_##ann##_as_##type)                               \
                                                                               \
     StrictMock<ASTMockVisitor> v;                                             \
     Expectation exp;                                                          \
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));                   \
+    exp = EXPECT_CALL(v, visitProgram(_));                                    \
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);        \
     exp = EXPECT_CALL(v, visitArrayDecl(ArrayDeclEq(BuiltinType::type##_type))).After(exp);\
     exp = EXPECT_CALL(v, visitScopedIdentifier(                               \
         ScopedIdentifierEq(scope##_scope, "arr", ann##_ann))).After(exp);     \

--- a/odb-compiler/tests/src/parser/test_db_parser_assignment.cpp
+++ b/odb-compiler/tests/src/parser/test_db_parser_assignment.cpp
@@ -26,7 +26,8 @@ TEST_F(NAME, variable_with_assignment_has_default_type_integer)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("var", Annotation::NONE))).After(exp);
@@ -42,7 +43,8 @@ TEST_F(NAME, float_variable_with_assignment_has_type_float)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("var", Annotation::FLOAT))).After(exp);
@@ -58,7 +60,8 @@ TEST_F(NAME, string_variable_with_assignment_has_type_string)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("var", Annotation::STRING))).After(exp);

--- a/odb-compiler/tests/src/parser/test_db_parser_command.cpp
+++ b/odb-compiler/tests/src/parser/test_db_parser_command.cpp
@@ -46,7 +46,8 @@ TEST_F(NAME, print_command)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitCommandStmnt(CommandStmntEq("print"))).After(exp);
     exp = EXPECT_CALL(v, visitArgList(ArgListCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitStringLiteral(StringLiteralEq("hello world"))).After(exp);
@@ -65,7 +66,8 @@ TEST_F(NAME, command_with_spaces)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitCommandStmnt(CommandStmntEq("make object sphere"))).After(exp);
     exp = EXPECT_CALL(v, visitArgList(ArgListCountEq(2))).After(exp);
     exp = EXPECT_CALL(v, visitByteLiteral(ByteLiteralEq(1))).After(exp);
@@ -86,7 +88,8 @@ TEST_F(NAME, randomize_timer)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitCommandStmnt(CommandStmntEq("randomize"))).After(exp);
     exp = EXPECT_CALL(v, visitArgList(ArgListCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitCommandExpr(CommandExprEq("timer"))).After(exp);
@@ -106,7 +109,8 @@ TEST_F(NAME, randomize_timer_args)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitCommandStmnt(CommandStmntEq("randomize"))).After(exp);
     exp = EXPECT_CALL(v, visitArgList(ArgListCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitCommandExpr(CommandExprEq("timer"))).After(exp);
@@ -128,7 +132,8 @@ TEST_F(NAME, command_with_string_annotation)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitCommandStmnt(CommandStmntEq("print"))).After(exp);
     exp = EXPECT_CALL(v, visitArgList(ArgListCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitCommandExpr(CommandExprEq("str$"))).After(exp);
@@ -150,7 +155,8 @@ TEST_F(NAME, command_with_float_annotation)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitCommandStmnt(CommandStmntEq("print"))).After(exp);
     exp = EXPECT_CALL(v, visitArgList(ArgListCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitCommandExpr(CommandExprEq("str#"))).After(exp);
@@ -171,7 +177,8 @@ TEST_F(NAME, load_3d_sound)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitCommandStmnt(_)).After(exp);
     exp = EXPECT_CALL(v, visitArgList(ArgListCountEq(2))).After(exp);
     exp = EXPECT_CALL(v, visitStringLiteral(StringLiteralEq("howl.wav"))).After(exp);
@@ -192,7 +199,8 @@ TEST_F(NAME, command_with_variable_args)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitCommandStmnt(CommandStmntEq("clone sound"))).After(exp);
     exp = EXPECT_CALL(v, visitArgList(ArgListCountEq(2))).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
@@ -214,7 +222,8 @@ TEST_F(NAME, command_with_spaces_as_argument_to_command_with_spaces)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitCommandStmnt(CommandStmntEq("make object sphere"))).After(exp);
     exp = EXPECT_CALL(v, visitArgList(ArgListCountEq(2))).After(exp);
     exp = EXPECT_CALL(v, visitCommandExpr(CommandExprEq("get ground height"))).After(exp);
@@ -242,7 +251,8 @@ TEST_F(NAME, command_starting_with_builtin)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitCommandStmnt(CommandStmntEq("loop sound"))).After(exp);
     exp = EXPECT_CALL(v, visitArgList(ArgListCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitByteLiteral(ByteLiteralEq(1))).After(exp);
@@ -263,7 +273,8 @@ TEST_F(NAME, builtin_shadowing_command)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitInfiniteLoop(_)).After(exp);
     exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitFuncCallStmnt(_)).After(exp);
@@ -284,7 +295,8 @@ TEST_F(NAME, multiple_similar_commands_with_spaces)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitCommandStmnt(CommandStmntEq("set object speed"))).After(exp);
     exp = EXPECT_CALL(v, visitArgList(ArgListCountEq(2))).After(exp);
     exp = EXPECT_CALL(v, visitByteLiteral(ByteLiteralEq(1))).After(exp);
@@ -308,7 +320,8 @@ TEST_F(NAME, multiple_similar_commands_with_spaces_2)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitCommandStmnt(CommandStmntEq("set object collision off"))).After(exp);
     exp = EXPECT_CALL(v, visitArgList(ArgListCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitByteLiteral(ByteLiteralEq(1))).After(exp);
@@ -329,7 +342,8 @@ TEST_F(NAME, incomplete_command_at_end_of_file)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitFuncDecl(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("foo", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);

--- a/odb-compiler/tests/src/parser/test_db_parser_constant.cpp
+++ b/odb-compiler/tests/src/parser/test_db_parser_constant.cpp
@@ -29,7 +29,8 @@ TEST_F(NAME, bool_constant)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(2)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(2))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("mybool1", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitBooleanLiteral(BooleanLiteralEq(true))).After(exp);
@@ -49,7 +50,8 @@ TEST_F(NAME, integer_constant)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("myint", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitIntegerLiteral(IntegerLiteralEq(2147483647)));
@@ -66,7 +68,8 @@ TEST_F(NAME, double_constant)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("mydouble", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitDoubleFloatLiteral(DoubleFloatLiteralEq(5.2)));
@@ -83,7 +86,8 @@ TEST_F(NAME, double_constant_annotated)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("mydouble", Annotation::FLOAT))).After(exp);
     exp = EXPECT_CALL(v, visitDoubleFloatLiteral(DoubleFloatLiteralEq(5.2)));
@@ -100,7 +104,8 @@ TEST_F(NAME, string_constant)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("mystring", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitStringLiteral(StringLiteralEq("hello world!")));
@@ -117,7 +122,8 @@ TEST_F(NAME, string_constant_annotated)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("mystring", Annotation::STRING))).After(exp);
     exp = EXPECT_CALL(v, visitStringLiteral(StringLiteralEq("hello world!")));

--- a/odb-compiler/tests/src/parser/test_db_parser_func_call.cpp
+++ b/odb-compiler/tests/src/parser/test_db_parser_func_call.cpp
@@ -30,7 +30,8 @@ TEST_F(NAME, function_call_no_args)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitFuncCallStmnt(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("foo", Annotation::NONE))).After(exp);
 
@@ -44,7 +45,8 @@ TEST_F(NAME, function_call_no_args_string_return_type)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitFuncCallStmnt(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("foo", Annotation::STRING))).After(exp);
 
@@ -58,7 +60,8 @@ TEST_F(NAME, function_call_no_args_float_return_type)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitFuncCallStmnt(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("foo", Annotation::FLOAT))).After(exp);
 
@@ -72,7 +75,8 @@ TEST_F(NAME, function_call_one_arg)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitFuncCallStmnt(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("foo", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitArgList(ArgListCountEq(1))).After(exp);
@@ -88,7 +92,8 @@ TEST_F(NAME, function_call_multiple_args)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitFuncCallStmnt(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("foo", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitArgList(ArgListCountEq(3))).After(exp);
@@ -106,7 +111,8 @@ TEST_F(NAME, nested_function_calls)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitFuncCallStmnt(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("foo", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitArgList(ArgListCountEq(3))).After(exp);

--- a/odb-compiler/tests/src/parser/test_db_parser_inc_dec.cpp
+++ b/odb-compiler/tests/src/parser/test_db_parser_inc_dec.cpp
@@ -27,7 +27,8 @@ TEST_F(NAME, inc_var_by_1)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
@@ -46,7 +47,8 @@ TEST_F(NAME, inc_var_by_10)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
@@ -65,7 +67,8 @@ TEST_F(NAME, inc_var_by_expr)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
@@ -88,7 +91,8 @@ TEST_F(NAME, dec_var_by_1)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
@@ -107,7 +111,8 @@ TEST_F(NAME, dec_var_by_10)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
@@ -126,7 +131,8 @@ TEST_F(NAME, dec_var_by_expr)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
@@ -149,7 +155,8 @@ TEST_F(NAME, inc_arr_by_1)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitArrayAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitArrayRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
@@ -174,7 +181,8 @@ TEST_F(NAME, inc_arr_by_10)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitArrayAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitArrayRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
@@ -199,7 +207,8 @@ TEST_F(NAME, inc_arr_by_expr)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitArrayAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitArrayRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
@@ -228,7 +237,8 @@ TEST_F(NAME, dec_arr_by_1)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitArrayAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitArrayRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
@@ -253,7 +263,8 @@ TEST_F(NAME, dec_arr_by_10)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitArrayAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitArrayRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
@@ -278,7 +289,8 @@ TEST_F(NAME, dec_arr_by_expr)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitArrayAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitArrayRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
@@ -307,7 +319,8 @@ TEST_F(NAME, inc_udt_by_1)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldOuter(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
@@ -332,7 +345,8 @@ TEST_F(NAME, inc_udt_by_10)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldOuter(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
@@ -357,7 +371,8 @@ TEST_F(NAME, inc_udt_by_expr)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldOuter(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
@@ -386,7 +401,8 @@ TEST_F(NAME, dec_udt_by_1)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldOuter(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
@@ -411,7 +427,8 @@ TEST_F(NAME, dec_udt_by_10)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldOuter(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
@@ -436,7 +453,8 @@ TEST_F(NAME, dec_udt_by_expr)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldOuter(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);

--- a/odb-compiler/tests/src/parser/test_db_parser_literal_bool.cpp
+++ b/odb-compiler/tests/src/parser/test_db_parser_literal_bool.cpp
@@ -28,7 +28,8 @@ TEST_F(NAME, bool_true)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitBooleanLiteral(BooleanLiteralEq(true))).After(exp);
@@ -45,7 +46,8 @@ TEST_F(NAME, bool_false)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitBooleanLiteral(BooleanLiteralEq(false))).After(exp);

--- a/odb-compiler/tests/src/parser/test_db_parser_literal_complex.cpp
+++ b/odb-compiler/tests/src/parser/test_db_parser_literal_complex.cpp
@@ -31,7 +31,8 @@ TEST_F(NAME, real_plus_imag)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(2)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(2))).After(exp);
     for (int i = 0; i != 2; ++i)
     {
         const char* vars[] = {"a", "b"};
@@ -55,7 +56,8 @@ TEST_F(NAME, real_minus_imag)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(2)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(2))).After(exp);
     for (int i = 0; i != 2; ++i)
     {
         const char* vars[] = {"a", "b"};
@@ -81,7 +83,8 @@ TEST_F(NAME, imag_only)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(4)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(4))).After(exp);
     for (int i = 0; i != 4; ++i)
     {
         const char* vars[] = {"a", "b", "c", "d"};
@@ -105,7 +108,8 @@ TEST_F(NAME, negative_imag_only)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(4)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(4))).After(exp);
     for (int i = 0; i != 4; ++i)
     {
         const char* vars[] = {"a", "b", "c", "d"};

--- a/odb-compiler/tests/src/parser/test_db_parser_literal_float.cpp
+++ b/odb-compiler/tests/src/parser/test_db_parser_literal_float.cpp
@@ -27,7 +27,8 @@ TEST_F(NAME, double_1_notation)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitDoubleFloatLiteral(DoubleFloatLiteralEq(53))).After(exp);
@@ -44,7 +45,8 @@ TEST_F(NAME, double_2_notation)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitDoubleFloatLiteral(DoubleFloatLiteralEq(.53))).After(exp);
@@ -61,7 +63,8 @@ TEST_F(NAME, float_1_notation)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitFloatLiteral(FloatLiteralEq(53))).After(exp);
@@ -78,7 +81,8 @@ TEST_F(NAME, float_2_notation)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitFloatLiteral(FloatLiteralEq(.53))).After(exp);
@@ -95,7 +99,8 @@ TEST_F(NAME, float_3_notation)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitFloatLiteral(FloatLiteralEq(53))).After(exp);
@@ -112,7 +117,8 @@ TEST_F(NAME, double_exponential_notation_1)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitDoubleFloatLiteral(DoubleFloatLiteralEq(12e2))).After(exp);
@@ -129,7 +135,8 @@ TEST_F(NAME, double_exponential_notation_2)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitDoubleFloatLiteral(DoubleFloatLiteralEq(12.4e2))).After(exp);
@@ -146,7 +153,8 @@ TEST_F(NAME, double_exponential_notation_3)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitDoubleFloatLiteral(DoubleFloatLiteralEq(40))).After(exp);
@@ -163,7 +171,8 @@ TEST_F(NAME, double_exponential_notation_4)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitDoubleFloatLiteral(DoubleFloatLiteralEq(4300))).After(exp);
@@ -180,7 +189,8 @@ TEST_F(NAME, double_exponential_notation_5)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitDoubleFloatLiteral(DoubleFloatLiteralEq(0.12))).After(exp);
@@ -197,7 +207,8 @@ TEST_F(NAME, double_exponential_notation_6)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitDoubleFloatLiteral(DoubleFloatLiteralEq(0.124))).After(exp);
@@ -214,7 +225,8 @@ TEST_F(NAME, double_exponential_notation_7)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitDoubleFloatLiteral(DoubleFloatLiteralEq(0.004))).After(exp);
@@ -231,7 +243,8 @@ TEST_F(NAME, double_exponential_notation_8)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitDoubleFloatLiteral(DoubleFloatLiteralEq(0.43))).After(exp);
@@ -248,7 +261,8 @@ TEST_F(NAME, double_exponential_notation_9)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitDoubleFloatLiteral(DoubleFloatLiteralEq(12e2))).After(exp);
@@ -265,7 +279,8 @@ TEST_F(NAME, double_exponential_notation_10)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitDoubleFloatLiteral(DoubleFloatLiteralEq(12.4e2))).After(exp);
@@ -282,7 +297,8 @@ TEST_F(NAME, double_exponential_notation_11)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitDoubleFloatLiteral(DoubleFloatLiteralEq(40))).After(exp);
@@ -299,7 +315,8 @@ TEST_F(NAME, double_exponential_notation_12)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitDoubleFloatLiteral(DoubleFloatLiteralEq(4300))).After(exp);
@@ -316,7 +333,8 @@ TEST_F(NAME, float_exponential_notation_1)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitFloatLiteral(FloatLiteralEq(12e2))).After(exp);
@@ -333,7 +351,8 @@ TEST_F(NAME, float_exponential_notation_2)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitFloatLiteral(FloatLiteralEq(12.4e2))).After(exp);
@@ -350,7 +369,8 @@ TEST_F(NAME, float_exponential_notation_3)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitFloatLiteral(FloatLiteralEq(40))).After(exp);
@@ -367,7 +387,8 @@ TEST_F(NAME, float_exponential_notation_4)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitFloatLiteral(FloatLiteralEq(4300))).After(exp);
@@ -384,7 +405,8 @@ TEST_F(NAME, float_exponential_notation_5)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitFloatLiteral(FloatLiteralEq(0.12))).After(exp);
@@ -401,7 +423,8 @@ TEST_F(NAME, float_exponential_notation_6)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitFloatLiteral(FloatLiteralEq(0.124))).After(exp);
@@ -418,7 +441,8 @@ TEST_F(NAME, float_exponential_notation_7)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitFloatLiteral(FloatLiteralEq(0.004))).After(exp);
@@ -435,7 +459,8 @@ TEST_F(NAME, float_exponential_notation_8)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitFloatLiteral(FloatLiteralEq(0.43))).After(exp);

--- a/odb-compiler/tests/src/parser/test_db_parser_literal_int.cpp
+++ b/odb-compiler/tests/src/parser/test_db_parser_literal_int.cpp
@@ -29,7 +29,8 @@ TEST_F(NAME, value_of_0_and_1_is_type_byte_and_not_boolean)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(2)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(2))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("x", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitByteLiteral(ByteLiteralEq(0))).After(exp);
@@ -50,7 +51,8 @@ TEST_F(NAME, byte_literal)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(2)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(2))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("x", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitByteLiteral(ByteLiteralEq(2))).After(exp);
@@ -71,7 +73,8 @@ TEST_F(NAME, word_literal)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(2)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(2))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("x", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitWordLiteral(WordLiteralEq(256))).After(exp);
@@ -92,7 +95,8 @@ TEST_F(NAME, integer_literal)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(2)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(2))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("x", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitIntegerLiteral(IntegerLiteralEq(65536))).After(exp);
@@ -113,7 +117,8 @@ TEST_F(NAME, dword_literal)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(2)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(2))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("x", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitDwordLiteral(DwordLiteralEq(2147483648))).After(exp);
@@ -134,7 +139,8 @@ TEST_F(NAME, double_integer_literal)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(2)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(2))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("x", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitDoubleIntegerLiteral(DoubleIntegerLiteralEq(4294967296))).After(exp);
@@ -158,7 +164,8 @@ TEST_F(NAME, hex_literals)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(5)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(5))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitByteLiteral(ByteLiteralEq(0xFF))).After(exp);
@@ -191,7 +198,8 @@ TEST_F(NAME, binary_literals)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(5)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(5))).After(exp);
     exp = EXPECT_CALL(v, visitConstDeclExpr(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("a", Annotation::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitByteLiteral(ByteLiteralEq(0xFF))).After(exp);

--- a/odb-compiler/tests/src/parser/test_db_parser_literal_string.cpp
+++ b/odb-compiler/tests/src/parser/test_db_parser_literal_string.cpp
@@ -59,7 +59,8 @@ TEST_F(NAME, empty_string)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("x", Annotation::NONE))).After(exp);

--- a/odb-compiler/tests/src/parser/test_db_parser_location_info.cpp
+++ b/odb-compiler/tests/src/parser/test_db_parser_location_info.cpp
@@ -28,7 +28,7 @@ TEST_F(NAME, oneline_function_call)
         matcher);
     ASSERT_THAT(ast, NotNull());
 
-    const auto& stmnts = ast->statements();
+    const auto& stmnts = ast->body()->statements();
     ASSERT_THAT(stmnts.size(), Eq(1));
     ast::VarAssignment* ass = dynamic_cast<ast::VarAssignment*>(stmnts[0].get());
     ASSERT_THAT(ass, NotNull());
@@ -82,7 +82,7 @@ TEST_F(NAME, print_command)
         matcher);
     ASSERT_THAT(ast, NotNull());
 
-    const auto& stmnts = ast->statements();
+    const auto& stmnts = ast->body()->statements();
     ASSERT_THAT(stmnts.size(), Eq(1));
     ast::Conditional* cond = dynamic_cast<ast::Conditional*>(stmnts[0].get());
     ASSERT_THAT(cond, NotNull());

--- a/odb-compiler/tests/src/parser/test_db_parser_op_precedence.cpp
+++ b/odb-compiler/tests/src/parser/test_db_parser_op_precedence.cpp
@@ -28,7 +28,8 @@ using namespace ast;
                                                                               \
         StrictMock<ASTMockVisitor> v;                                         \
         Expectation exp;                                                      \
-        exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));               \
+        exp = EXPECT_CALL(v, visitProgram(_));                                \
+        exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);    \
         exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);               \
         exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);                      \
         exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("result", Annotation::NONE))).After(exp); \
@@ -50,7 +51,8 @@ using namespace ast;
                                                                               \
         StrictMock<ASTMockVisitor> v;                                         \
         Expectation exp;                                                      \
-        exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));               \
+        exp = EXPECT_CALL(v, visitProgram(_));                                \
+        exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);    \
         exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);               \
         exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);                      \
         exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("result", Annotation::NONE))).After(exp); \
@@ -74,7 +76,8 @@ using namespace ast;
                                                                               \
         StrictMock<ASTMockVisitor> v;                                         \
         Expectation exp;                                                      \
-        exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));               \
+        exp = EXPECT_CALL(v, visitProgram(_));                                \
+        exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);    \
         exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);               \
         exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);                      \
         exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("result", Annotation::NONE))).After(exp); \
@@ -96,7 +99,8 @@ using namespace ast;
                                                                               \
         StrictMock<ASTMockVisitor> v;                                         \
         Expectation exp;                                                      \
-        exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));               \
+        exp = EXPECT_CALL(v, visitProgram(_));                                \
+        exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);    \
         exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);               \
         exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);                      \
         exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("result", Annotation::NONE))).After(exp); \
@@ -120,7 +124,8 @@ using namespace ast;
                                                                               \
         StrictMock<ASTMockVisitor> v;                                         \
         Expectation exp;                                                      \
-        exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));               \
+        exp = EXPECT_CALL(v, visitProgram(_));                                \
+        exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);    \
         exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);               \
         exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);                      \
         exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("result", Annotation::NONE))).After(exp); \
@@ -138,7 +143,8 @@ using namespace ast;
                                                                               \
         StrictMock<ASTMockVisitor> v;                                         \
         Expectation exp;                                                      \
-        exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));               \
+        exp = EXPECT_CALL(v, visitProgram(_));                                \
+        exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);    \
         exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);               \
         exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);                      \
         exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("result", Annotation::NONE))).After(exp); \

--- a/odb-compiler/tests/src/parser/test_db_parser_remarks.cpp
+++ b/odb-compiler/tests/src/parser/test_db_parser_remarks.cpp
@@ -40,7 +40,8 @@ public:
 
             StrictMock<ASTMockVisitor> v;
             Expectation exp;
-            exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+            exp = EXPECT_CALL(v, visitProgram(_));
+            exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
             exp = EXPECT_CALL(v, visitFuncCallStmnt(_)).After(exp);
             exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("foo", Annotation::NONE))).After(exp);
 

--- a/odb-compiler/tests/src/parser/test_db_parser_udt_fields.cpp
+++ b/odb-compiler/tests/src/parser/test_db_parser_udt_fields.cpp
@@ -86,7 +86,8 @@ TEST_F(NAME, udt_ass_value)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldOuter(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
@@ -111,7 +112,8 @@ TEST_F(NAME, udt_float_ass_value)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldOuter(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
@@ -136,7 +138,8 @@ TEST_F(NAME, udt_string_ass_value)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldOuter(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
@@ -161,7 +164,8 @@ TEST_F(NAME, udt_arr_ass_value)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldOuter(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
@@ -189,7 +193,8 @@ TEST_F(NAME, udt_arr_float_ass_value)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldOuter(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
@@ -217,7 +222,8 @@ TEST_F(NAME, udt_arr_string_ass_value)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldOuter(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
@@ -245,7 +251,8 @@ TEST_F(NAME, udt_inner_arr_ass_value)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldOuter(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
@@ -273,7 +280,8 @@ TEST_F(NAME, udt_outer_arr_ass_value)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldOuter(_)).After(exp);
     exp = EXPECT_CALL(v, visitArrayRef(_)).After(exp);
@@ -301,7 +309,8 @@ TEST_F(NAME, value_ass_udt)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("value", Annotation::NONE))).After(exp);
@@ -326,7 +335,8 @@ TEST_F(NAME, value_ass_udt_float)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("value", Annotation::NONE))).After(exp);
@@ -351,7 +361,8 @@ TEST_F(NAME, value_ass_udt_string)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("value", Annotation::NONE))).After(exp);
@@ -376,7 +387,8 @@ TEST_F(NAME, value_ass_udt_arr)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("value", Annotation::NONE))).After(exp);
@@ -404,7 +416,8 @@ TEST_F(NAME, value_ass_udt_arr_float)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("value", Annotation::NONE))).After(exp);
@@ -432,7 +445,8 @@ TEST_F(NAME, value_ass_udt_arr_string)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("value", Annotation::NONE))).After(exp);
@@ -460,7 +474,8 @@ TEST_F(NAME, value_ass_udt_inner_arr)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("value", Annotation::NONE))).After(exp);
@@ -488,7 +503,8 @@ TEST_F(NAME, value_ass_udt_outer_arr)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("value", Annotation::NONE))).After(exp);
@@ -516,7 +532,8 @@ TEST_F(NAME, value_ass_func_returning_udt)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("value", Annotation::NONE))).After(exp);
@@ -543,7 +560,8 @@ TEST_F(NAME, value_ass_command_returning_udt)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("value", Annotation::NONE))).After(exp);
@@ -567,7 +585,8 @@ TEST_F(NAME, udt_inner_float_ass_value)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldOuter(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
@@ -592,7 +611,8 @@ TEST_F(NAME, udt_inner_string_ass_value)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldOuter(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
@@ -617,7 +637,8 @@ TEST_F(NAME, udt_outer_float_ass_value)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldOuter(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
@@ -642,7 +663,8 @@ TEST_F(NAME, udt_outer_string_ass_value)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldOuter(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
@@ -667,7 +689,8 @@ TEST_F(NAME, udt_inner_float_arr_ass_value)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldOuter(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
@@ -695,7 +718,8 @@ TEST_F(NAME, udt_inner_string_arr_ass_value)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldOuter(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
@@ -723,7 +747,8 @@ TEST_F(NAME, udt_outer_float_arr_ass_value)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldOuter(_)).After(exp);
     exp = EXPECT_CALL(v, visitArrayRef(_)).After(exp);
@@ -751,7 +776,8 @@ TEST_F(NAME, udt_outer_string_arr_ass_value)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitUDTFieldOuter(_)).After(exp);
     exp = EXPECT_CALL(v, visitArrayRef(_)).After(exp);
@@ -821,7 +847,8 @@ TEST_F(NAME, value_ass_udt_inner_float)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("value", Annotation::NONE))).After(exp);
@@ -846,7 +873,8 @@ TEST_F(NAME, value_ass_udt_outer_float)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("value", Annotation::NONE))).After(exp);
@@ -871,7 +899,8 @@ TEST_F(NAME, value_ass_udt_inner_string)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("value", Annotation::NONE))).After(exp);
@@ -896,7 +925,8 @@ TEST_F(NAME, value_ass_udt_outer_string)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("value", Annotation::NONE))).After(exp);
@@ -921,7 +951,8 @@ TEST_F(NAME, value_ass_udt_inner_float_arr)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("value", Annotation::NONE))).After(exp);
@@ -949,7 +980,8 @@ TEST_F(NAME, value_ass_udt_inner_string_arr)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("value", Annotation::NONE))).After(exp);
@@ -977,7 +1009,8 @@ TEST_F(NAME, value_ass_udt_outer_float_arr)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("value", Annotation::NONE))).After(exp);
@@ -1005,7 +1038,8 @@ TEST_F(NAME, value_ass_udt_outer_string_arr)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("value", Annotation::NONE))).After(exp);
@@ -1033,7 +1067,8 @@ TEST_F(NAME, value_ass_float_func_returning_udt)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("value", Annotation::NONE))).After(exp);
@@ -1060,7 +1095,8 @@ TEST_F(NAME, value_ass_float_command_returning_udt)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("value", Annotation::NONE))).After(exp);
@@ -1084,7 +1120,8 @@ TEST_F(NAME, value_ass_string_func_returning_udt)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("value", Annotation::NONE))).After(exp);
@@ -1111,7 +1148,8 @@ TEST_F(NAME, value_ass_string_command_returning_udt)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarAssignment(_)).After(exp);
     exp = EXPECT_CALL(v, visitVarRef(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("value", Annotation::NONE))).After(exp);

--- a/odb-compiler/tests/src/parser/test_db_parser_udt_var_decl.cpp
+++ b/odb-compiler/tests/src/parser/test_db_parser_udt_var_decl.cpp
@@ -1260,7 +1260,8 @@ TEST_F(NAME, var_decl_as_double_integer)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDecl(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("udt"))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDeclBody(_)).After(exp);
@@ -1283,7 +1284,8 @@ TEST_F(NAME, var_decl_as_integer)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDecl(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("udt"))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDeclBody(_)).After(exp);
@@ -1306,7 +1308,8 @@ TEST_F(NAME, var_decl_as_dword)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDecl(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("udt"))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDeclBody(_)).After(exp);
@@ -1329,7 +1332,8 @@ TEST_F(NAME, var_decl_as_word)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDecl(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("udt"))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDeclBody(_)).After(exp);
@@ -1352,7 +1356,8 @@ TEST_F(NAME, var_decl_as_byte)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDecl(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("udt"))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDeclBody(_)).After(exp);
@@ -1375,7 +1380,8 @@ TEST_F(NAME, var_decl_as_boolean)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDecl(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("udt"))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDeclBody(_)).After(exp);
@@ -1398,7 +1404,8 @@ TEST_F(NAME, var_decl_as_double_float)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDecl(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("udt"))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDeclBody(_)).After(exp);
@@ -1421,7 +1428,8 @@ TEST_F(NAME, var_decl_as_float)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDecl(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("udt"))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDeclBody(_)).After(exp);
@@ -1444,7 +1452,8 @@ TEST_F(NAME, float_var_decl_as_float)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDecl(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("udt"))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDeclBody(_)).After(exp);
@@ -1467,7 +1476,8 @@ TEST_F(NAME, var_decl_as_string)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDecl(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("udt"))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDeclBody(_)).After(exp);
@@ -1490,7 +1500,8 @@ TEST_F(NAME, string_var_decl_as_string)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDecl(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("udt"))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDeclBody(_)).After(exp);
@@ -1513,7 +1524,8 @@ TEST_F(NAME, var_decl_as_nested_udt)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDecl(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("udt"))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDeclBody(_)).After(exp);
@@ -1534,7 +1546,8 @@ TEST_F(NAME, arr_decl_as_double_integer)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDecl(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("udt"))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDeclBody(_)).After(exp);
@@ -1558,7 +1571,8 @@ TEST_F(NAME, arr_decl_as_integer)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDecl(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("udt"))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDeclBody(_)).After(exp);
@@ -1582,7 +1596,8 @@ TEST_F(NAME, arr_decl_as_dword)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDecl(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("udt"))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDeclBody(_)).After(exp);
@@ -1606,7 +1621,8 @@ TEST_F(NAME, arr_decl_as_word)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDecl(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("udt"))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDeclBody(_)).After(exp);
@@ -1630,7 +1646,8 @@ TEST_F(NAME, arr_decl_as_byte)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDecl(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("udt"))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDeclBody(_)).After(exp);
@@ -1654,7 +1671,8 @@ TEST_F(NAME, arr_decl_as_boolean)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDecl(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("udt"))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDeclBody(_)).After(exp);
@@ -1678,7 +1696,8 @@ TEST_F(NAME, arr_decl_as_double_float)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDecl(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("udt"))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDeclBody(_)).After(exp);
@@ -1702,7 +1721,8 @@ TEST_F(NAME, arr_decl_as_float)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDecl(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("udt"))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDeclBody(_)).After(exp);
@@ -1726,7 +1746,8 @@ TEST_F(NAME, float_arr_decl_as_float)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDecl(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("udt"))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDeclBody(_)).After(exp);
@@ -1750,7 +1771,8 @@ TEST_F(NAME, arr_decl_as_string)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDecl(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("udt"))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDeclBody(_)).After(exp);
@@ -1774,7 +1796,8 @@ TEST_F(NAME, string_arr_decl_as_string)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDecl(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("udt"))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDeclBody(_)).After(exp);
@@ -1798,7 +1821,8 @@ TEST_F(NAME, arr_decl_as_nested_udt)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDecl(_)).After(exp);
     exp = EXPECT_CALL(v, visitIdentifier(IdentifierEq("udt"))).After(exp);
     exp = EXPECT_CALL(v, visitUDTDeclBody(_)).After(exp);

--- a/odb-compiler/tests/src/parser/test_db_parser_var_decl.cpp
+++ b/odb-compiler/tests/src/parser/test_db_parser_var_decl.cpp
@@ -151,7 +151,8 @@ TEST_F(NAME, scope##_var_##ann##_defaults_to_##type)                          \
                                                                               \
     StrictMock<ASTMockVisitor> v;                                             \
     Expectation exp;                                                          \
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));                   \
+    exp = EXPECT_CALL(v, visitProgram(_));                                    \
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);        \
     exp = EXPECT_CALL(v, visitVarDecl(VarDeclEq(BuiltinType::type##_type))).After(exp);\
     exp = EXPECT_CALL(v, visitScopedIdentifier(                               \
         ScopedIdentifierEq(scope##_scope, "var", ann##_ann))).After(exp);     \
@@ -194,7 +195,8 @@ TEST_F(NAME, scope##_var_##ann##_with_assignment_defaults_to_##type)          \
                                                                               \
     StrictMock<ASTMockVisitor> v;                                             \
     Expectation exp;                                                          \
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));                   \
+    exp = EXPECT_CALL(v, visitProgram(_));                                    \
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);        \
     exp = EXPECT_CALL(v, visitVarDecl(VarDeclEq(BuiltinType::type##_type))).After(exp);\
     exp = EXPECT_CALL(v, visitScopedIdentifier(                               \
         ScopedIdentifierEq(scope##_scope, "var", ann##_ann))).After(exp);     \
@@ -269,7 +271,8 @@ TEST_F(NAME, scope##_var_##ann##_as_##as_type)                                \
                                                                               \
     StrictMock<ASTMockVisitor> v;                                             \
     Expectation exp;                                                          \
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));                   \
+    exp = EXPECT_CALL(v, visitProgram(_));                                    \
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);        \
     exp = EXPECT_CALL(v, visitVarDecl(VarDeclEq(BuiltinType::as_type##_type))).After(exp);\
     exp = EXPECT_CALL(v, visitScopedIdentifier(                               \
         ScopedIdentifierEq(scope##_scope, "var", ann##_ann))).After(exp);     \
@@ -355,7 +358,8 @@ TEST_F(NAME, scope##_var_##ann##_as_##as_type##_with_initial_value)           \
                                                                               \
     StrictMock<ASTMockVisitor> v;                                             \
     Expectation exp;                                                          \
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));                   \
+    exp = EXPECT_CALL(v, visitProgram(_));                                    \
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);        \
     exp = EXPECT_CALL(v, visitVarDecl(VarDeclEq(BuiltinType::as_type##_type))).After(exp);               \
     exp = EXPECT_CALL(v, visitScopedIdentifier(                               \
         ScopedIdentifierEq(scope##_scope, "var", ann##_ann))).After(exp);     \

--- a/odb-compiler/tests/src/parser/test_db_parser_var_decl_math.cpp
+++ b/odb-compiler/tests/src/parser/test_db_parser_var_decl_math.cpp
@@ -181,7 +181,8 @@ TEST_F(NAME, scope##_var_##ann##_as_##as_type)                                \
                                                                               \
     StrictMock<ASTMockVisitor> v;                                             \
     Expectation exp;                                                          \
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));                   \
+    exp = EXPECT_CALL(v, visitProgram(_));                                    \
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);        \
     exp = EXPECT_CALL(v, visitVarDecl(VarDeclEq(BuiltinType::as_type##_type))).After(exp);               \
     exp = EXPECT_CALL(v, visitScopedIdentifier(                          \
         ScopedIdentifierEq(scope##_scope, "var", ann##_ann))).After(exp);\
@@ -255,7 +256,8 @@ TEST_F(NAME, var_as_complex_with_complex_literal_initializer)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarDecl(VarDeclEq(BuiltinType::Complex))).After(exp);
     exp = EXPECT_CALL(v, visitScopedIdentifier(ScopedIdentifierEq(Scope::LOCAL, "var", Ann::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitInitializerList(InitializerListCountEq(1))).After(exp);
@@ -275,7 +277,8 @@ TEST_F(NAME, var_as_complex_with_complex_initializer_list)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarDecl(VarDeclEq(BuiltinType::Complex))).After(exp);
     exp = EXPECT_CALL(v, visitScopedIdentifier(ScopedIdentifierEq(Scope::LOCAL, "var", Ann::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitInitializerList(InitializerListCountEq(2))).After(exp);
@@ -294,7 +297,8 @@ TEST_F(NAME, var_as_quat_with_quat_literal_initializer)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarDecl(VarDeclEq(BuiltinType::Quat))).After(exp);
     exp = EXPECT_CALL(v, visitScopedIdentifier(ScopedIdentifierEq(Scope::LOCAL, "var", Ann::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitInitializerList(InitializerListCountEq(1))).After(exp);
@@ -318,7 +322,8 @@ TEST_F(NAME, var_as_quat_with_quat_initializer_list)
 
     StrictMock<ASTMockVisitor> v;
     Expectation exp;
-    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1)));
+    exp = EXPECT_CALL(v, visitProgram(_));
+    exp = EXPECT_CALL(v, visitBlock(BlockStmntCountEq(1))).After(exp);
     exp = EXPECT_CALL(v, visitVarDecl(VarDeclEq(BuiltinType::Quat))).After(exp);
     exp = EXPECT_CALL(v, visitScopedIdentifier(ScopedIdentifierEq(Scope::LOCAL, "var", Ann::NONE))).After(exp);
     exp = EXPECT_CALL(v, visitInitializerList(InitializerListCountEq(4))).After(exp);


### PR DESCRIPTION
* Added a root `Program` node. This node stores information (populated later) about the variables with global scope, and could eventually store DBPro project information (like screen resolution etc).
* Add `Variable` node, which represents a concrete variable object. Multiple nodes end up pointing to a single `Variable`, which is reolved in a later pass (implemented in a future PR).
* Add `ImplicitCast` node, which converts an inner expression from the expression type to a target type. `ImplicitCast`'s will be inserted during type checking (in a future MR).
* Added `Nodes.hpp`, which defines an X macro that lists all AST nodes. This is then used to auto-generate the visitor objects in `Visitor.hpp`, drastically reducing the boilerplate.